### PR TITLE
Add missing SaleToAcquirerData field

### DIFF
--- a/Sources/TerminalAPIKit/Models/SaleData.swift
+++ b/Sources/TerminalAPIKit/Models/SaleData.swift
@@ -43,6 +43,9 @@ public final class SaleData: Codable {
     
     /// Sale information intended for the Issuer.
     public let saleToIssuerData: SaleToIssuerData?
+
+    /// Sale information intended for the Acquirer.
+    public let saleToAcquirerData: String?
     
     /// Initializes the SaleData.
     ///
@@ -57,7 +60,8 @@ public final class SaleData: Codable {
     /// - Parameter customerOrderReq: Undocumented.
     /// - Parameter saleToPOIData: Sale information intended for the POI.
     /// - Parameter saleToIssuerData: Sale information intended for the Issuer.
-    public init(operatorIdentifier: String? = nil, operatorLanguage: String? = nil, shiftNumber: String? = nil, saleTransactionIdentifier: TransactionIdentifier, saleReferenceIdentifier: String? = nil, saleTerminalData: SaleTerminalData? = nil, tokenRequestedType: TokenRequestedType? = nil, customerOrderIdentifier: String? = nil, customerOrderReq: Set<CustomerOrderReq>? = nil, saleToPOIData: String? = nil, saleToIssuerData: SaleToIssuerData? = nil) {
+    /// - Parameter saleToAcquirerData: Sale information intended for the Acquirer.
+    public init(operatorIdentifier: String? = nil, operatorLanguage: String? = nil, shiftNumber: String? = nil, saleTransactionIdentifier: TransactionIdentifier, saleReferenceIdentifier: String? = nil, saleTerminalData: SaleTerminalData? = nil, tokenRequestedType: TokenRequestedType? = nil, customerOrderIdentifier: String? = nil, customerOrderReq: Set<CustomerOrderReq>? = nil, saleToPOIData: String? = nil, saleToIssuerData: SaleToIssuerData? = nil, saleToAcquirerData: String? = nil) {
         self.operatorIdentifier = operatorIdentifier
         self.operatorLanguage = operatorLanguage
         self.shiftNumber = shiftNumber
@@ -69,6 +73,7 @@ public final class SaleData: Codable {
         self.customerOrderReq = customerOrderReq
         self.saleToPOIData = saleToPOIData
         self.saleToIssuerData = saleToIssuerData
+        self.saleToAcquirerData = saleToAcquirerData
     }
     
     internal enum CodingKeys: String, CodingKey {
@@ -83,6 +88,7 @@ public final class SaleData: Codable {
         case customerOrderReq = "CustomerOrderReq"
         case saleToPOIData = "SaleToPOIData"
         case saleToIssuerData = "SaleToIssuerData"
+        case saleToAcquirerData = "SaleToAcquirerData"
     }
     
 }


### PR DESCRIPTION
## Summary
SaleToAcquirerData field was missing from SaleData. This field is used to relay information to the acquirer or the gateway.



