### PR TITLE
Make Responses initializers public

### DIFF
--- a/Sources/TerminalAPIKit/Models/Responses/AdminResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/AdminResponse.swift
@@ -20,7 +20,7 @@ public final class AdminResponse: Response {
     /// Initializes the AdminResponse.
     ///
     /// - Parameter response: Result of a message request processing.
-    internal init(response: MessageResponse) {
+    public init(response: MessageResponse) {
         self.response = response
     }
     

--- a/Sources/TerminalAPIKit/Models/Responses/BalanceInquiryResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/BalanceInquiryResponse.swift
@@ -32,7 +32,12 @@ public final class BalanceInquiryResponse: Response {
     /// - Parameter paymentAccountStatus: Data related to the result of a Balance Inquiry request.
     /// - Parameter loyaltyAccountStatus: Data related to the result of a loyalty Balance Inquiry.
     /// - Parameter paymentReceipt: Undocumented.
-    internal init(response: MessageResponse, paymentAccountStatus: PaymentAccountStatus? = nil, loyaltyAccountStatus: LoyaltyAccountStatus? = nil, paymentReceipt: [PaymentReceipt]? = nil) {
+    public init(
+        response: MessageResponse,
+        paymentAccountStatus: PaymentAccountStatus? = nil,
+        loyaltyAccountStatus: LoyaltyAccountStatus? = nil,
+        paymentReceipt: [PaymentReceipt]? = nil
+    ) {
         self.response = response
         self.paymentAccountStatus = paymentAccountStatus
         self.loyaltyAccountStatus = loyaltyAccountStatus

--- a/Sources/TerminalAPIKit/Models/Responses/CardAcquisitionResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/CardAcquisitionResponse.swift
@@ -40,7 +40,14 @@ public final class CardAcquisitionResponse: Response {
     /// - Parameter customerLanguage: Undocumented.
     /// - Parameter paymentBrand: Type of payment card
     /// - Parameter paymentInstrumentData: Data related to the instrument of payment for the transaction.
-    internal init(response: MessageResponse, saleData: SaleData, poiData: POIData, customerLanguage: String? = nil, paymentBrand: [String]? = nil, paymentInstrumentData: PaymentInstrumentData? = nil) {
+    public init(
+        response: MessageResponse,
+        saleData: SaleData,
+        poiData: POIData,
+        customerLanguage: String? = nil,
+        paymentBrand: [String]? = nil,
+        paymentInstrumentData: PaymentInstrumentData? = nil
+    ) {
         self.response = response
         self.saleData = saleData
         self.poiData = poiData

--- a/Sources/TerminalAPIKit/Models/Responses/DiagnosisResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/DiagnosisResponse.swift
@@ -32,7 +32,12 @@ public final class DiagnosisResponse: Response {
     /// - Parameter loggedSaleIdentifier: Sale Terminal logged to.
     /// - Parameter poiStatus: State of a POI Terminal.
     /// - Parameter hostStatus: State of a Host.
-    internal init(response: MessageResponse, loggedSaleIdentifier: [String]? = nil, poiStatus: POIStatus? = nil, hostStatus: [HostStatus]? = nil) {
+    public init(
+        response: MessageResponse,
+        loggedSaleIdentifier: [String]? = nil,
+        poiStatus: POIStatus? = nil,
+        hostStatus: [HostStatus]? = nil
+    ) {
         self.response = response
         self.loggedSaleIdentifier = loggedSaleIdentifier
         self.poiStatus = poiStatus

--- a/Sources/TerminalAPIKit/Models/Responses/DisplayResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/DisplayResponse.swift
@@ -20,7 +20,7 @@ public final class DisplayResponse: Response {
     /// Initializes the DisplayResponse.
     ///
     /// - Parameter outputResult: Information related to the result the output (display, print, input).
-    internal init(outputResult: [OutputResult]) {
+    public init(outputResult: [OutputResult]) {
         self.outputResult = outputResult
     }
     

--- a/Sources/TerminalAPIKit/Models/Responses/EnableServiceResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/EnableServiceResponse.swift
@@ -20,7 +20,7 @@ public final class EnableServiceResponse: Response {
     /// Initializes the EnableServiceResponse.
     ///
     /// - Parameter response: Result of a message request processing.
-    internal init(response: MessageResponse) {
+    public init(response: MessageResponse) {
         self.response = response
     }
     

--- a/Sources/TerminalAPIKit/Models/Responses/GetTotalsResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/GetTotalsResponse.swift
@@ -28,7 +28,11 @@ public final class GetTotalsResponse: Response {
     /// - Parameter response: Result of a message request processing.
     /// - Parameter poiReconciliationIdentifier: Identification of the reconciliation period between Sale and POI.
     /// - Parameter transactionTotals: Result of the Sale to POI Reconciliation processing.
-    internal init(response: MessageResponse, poiReconciliationIdentifier: String, transactionTotals: [TransactionTotals]? = nil) {
+    public init(
+        response: MessageResponse,
+        poiReconciliationIdentifier: String,
+        transactionTotals: [TransactionTotals]? = nil
+    ) {
         self.response = response
         self.poiReconciliationIdentifier = poiReconciliationIdentifier
         self.transactionTotals = transactionTotals

--- a/Sources/TerminalAPIKit/Models/Responses/InputResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/InputResponse.swift
@@ -24,7 +24,7 @@ public final class InputResponse: Response {
     ///
     /// - Parameter outputResult: Information related to the result the output (display, print, input).
     /// - Parameter inputResult: Information related to the result the input.
-    internal init(outputResult: OutputResult? = nil, inputResult: InputResult) {
+    public init(outputResult: OutputResult? = nil, inputResult: InputResult) {
         self.outputResult = outputResult
         self.inputResult = inputResult
     }

--- a/Sources/TerminalAPIKit/Models/Responses/LoginResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/LoginResponse.swift
@@ -32,7 +32,12 @@ public final class LoginResponse: Response {
     /// - Parameter poiSystemData: Information related to the POI System
     /// - Parameter tokenRequestStatus: Undocumented.
     /// - Parameter customerOrderStatus: Undocumented.
-    internal init(response: MessageResponse, poiSystemData: POISystemData? = nil, tokenRequestStatus: Bool? = nil, customerOrderStatus: Bool? = nil) {
+    public init(
+        response: MessageResponse,
+        poiSystemData: POISystemData? = nil, tokenRequestStatus:
+        Bool? = nil,
+        customerOrderStatus: Bool? = nil
+    ) {
         self.response = response
         self.poiSystemData = poiSystemData
         self.tokenRequestStatus = tokenRequestStatus

--- a/Sources/TerminalAPIKit/Models/Responses/PaymentResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/PaymentResponse.swift
@@ -44,7 +44,15 @@ public final class PaymentResponse: Response {
     /// - Parameter loyaltyResult: Data related to the result of a processed loyalty transaction.
     /// - Parameter paymentReceipt: Undocumented.
     /// - Parameter customerOrder: Undocumented.
-    internal init(response: MessageResponse, saleData: SaleData, poiData: POIData?, paymentResult: PaymentResult? = nil, loyaltyResult: [LoyaltyResult]? = nil, paymentReceipt: [PaymentReceipt]? = nil, customerOrder: [CustomerOrder]? = nil) {
+    public init(
+        response: MessageResponse,
+        saleData: SaleData,
+        poiData: POIData?,
+        paymentResult: PaymentResult? = nil,
+        loyaltyResult: [LoyaltyResult]? = nil,
+        paymentReceipt: [PaymentReceipt]? = nil,
+        customerOrder: [CustomerOrder]? = nil
+    ) {
         self.response = response
         self.saleData = saleData
         self.poiData = poiData

--- a/Sources/TerminalAPIKit/Models/Responses/PrintResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/PrintResponse.swift
@@ -24,7 +24,7 @@ public final class PrintResponse: Response {
     ///
     /// - Parameter documentQualifier: Qualification of the document to print to the Cashier or the Customer.
     /// - Parameter response: Result of a message request processing.
-    internal init(documentQualifier: DocumentQualifier, response: MessageResponse) {
+    public init(documentQualifier: DocumentQualifier, response: MessageResponse) {
         self.documentQualifier = documentQualifier
         self.response = response
     }

--- a/Sources/TerminalAPIKit/Models/Responses/ReconciliationResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/ReconciliationResponse.swift
@@ -32,7 +32,12 @@ public final class ReconciliationResponse: Response {
     /// - Parameter reconciliationType: Type of Reconciliation requested by the Sale to the POI.
     /// - Parameter poiReconciliationIdentifier: Identification of the reconciliation period between Sale and POI.
     /// - Parameter transactionTotals: Result of the Sale to POI Reconciliation processing.
-    internal init(response: MessageResponse, reconciliationType: ReconciliationType, poiReconciliationIdentifier: String? = nil, transactionTotals: [TransactionTotals]? = nil) {
+    public init(
+        response: MessageResponse,
+        reconciliationType: ReconciliationType,
+        poiReconciliationIdentifier: String? = nil,
+        transactionTotals: [TransactionTotals]? = nil
+    ) {
         self.response = response
         self.reconciliationType = reconciliationType
         self.poiReconciliationIdentifier = poiReconciliationIdentifier

--- a/Sources/TerminalAPIKit/Models/Responses/ReversalResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/ReversalResponse.swift
@@ -40,7 +40,14 @@ public final class ReversalResponse: Response {
     /// - Parameter reversedAmount: Amount of the payment or loyalty to reverse..
     /// - Parameter customerOrder: Undocumented.
     /// - Parameter paymentReceipt: Undocumented.
-    internal init(response: MessageResponse, poiData: POIData? = nil, originalPOITransaction: OriginalPOITransaction? = nil, reversedAmount: Double? = nil, customerOrder: [CustomerOrder]? = nil, paymentReceipt: [PaymentReceipt]? = nil) {
+    public init(
+        response: MessageResponse,
+        poiData: POIData? = nil,
+        originalPOITransaction: OriginalPOITransaction? = nil,
+        reversedAmount: Double? = nil,
+        customerOrder: [CustomerOrder]? = nil,
+        paymentReceipt: [PaymentReceipt]? = nil
+    ) {
         self.response = response
         self.poiData = poiData
         self.originalPOITransaction = originalPOITransaction

--- a/Sources/TerminalAPIKit/Models/Responses/StoredValueResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/StoredValueResponse.swift
@@ -36,7 +36,13 @@ public final class StoredValueResponse: Response {
     /// - Parameter poiData: Data related to the POI System.
     /// - Parameter storedValueResult: Result of loading/reloading a stored value card..
     /// - Parameter paymentReceipt: Undocumented.
-    internal init(response: MessageResponse, saleData: SaleData, poiData: POIData, storedValueResult: [StoredValueResult]? = nil, paymentReceipt: [PaymentReceipt]? = nil) {
+    public init(
+        response: MessageResponse,
+        saleData: SaleData,
+        poiData: POIData,
+        storedValueResult: [StoredValueResult]? = nil,
+        paymentReceipt: [PaymentReceipt]? = nil
+    ) {
         self.response = response
         self.saleData = saleData
         self.poiData = poiData

--- a/Sources/TerminalAPIKit/Models/Responses/TransactionStatusResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/TransactionStatusResponse.swift
@@ -28,7 +28,11 @@ public final class TransactionStatusResponse: Response {
     /// - Parameter response: Result of a message request processing.
     /// - Parameter messageReference: Identification of a previous POI transaction.
     /// - Parameter repeatedMessageResponse: Content of the requested Message Response.
-    internal init(response: MessageResponse, messageReference: MessageReference? = nil, repeatedMessageResponse: RepeatedMessageResponse? = nil) {
+    public init(
+        response: MessageResponse,
+        messageReference: MessageReference? = nil,
+        repeatedMessageResponse: RepeatedMessageResponse? = nil
+    ) {
         self.response = response
         self.messageReference = messageReference
         self.repeatedMessageResponse = repeatedMessageResponse


### PR DESCRIPTION
This PR makes the `init` of the Response objects public.
This will allow creating Response objects ad-hoc.