### PR TITLE
Change notification to SaleToPOIRequest

### DIFF
--- a/Sources/TerminalAPIKit/Coding/StringCodingKey.swift
+++ b/Sources/TerminalAPIKit/Coding/StringCodingKey.swift
@@ -22,9 +22,9 @@ internal extension StringCodingKey {
     
     init(for type: MessageType) {
         switch type {
-        case .request:
+        case .request, .notification:
             self.init(value: "SaleToPOIRequest")
-        case .response, .notification:
+        case .response:
             self.init(value: "SaleToPOIResponse")
         }
     }


### PR DESCRIPTION
This PR fixes an issue where `EventNotification` was wrapped in `SaleToPOIResponse`, while it should be wrapped in `SaleToPOIRequest`