### PR TITLE
Replace Double with Decimal

### DIFF
--- a/Sources/TerminalAPIKit/Models/Amounts.swift
+++ b/Sources/TerminalAPIKit/Models/Amounts.swift
@@ -13,25 +13,25 @@ public final class Amounts: Codable {
     public let currency: String
     
     /// Undocumented.
-    public let requestedAmount: Double?
+    public let requestedAmount: Decimal?
     
     /// Undocumented.
-    public let cashBackAmount: Double?
+    public let cashBackAmount: Decimal?
     
     /// Undocumented.
-    public let tipAmount: Double?
+    public let tipAmount: Decimal?
     
     /// Undocumented.
-    public let paidAmount: Double?
+    public let paidAmount: Decimal?
     
     /// Undocumented.
-    public let minimumAmountToDeliver: Double?
+    public let minimumAmountToDeliver: Decimal?
     
     /// Undocumented.
-    public let maximumCashBackAmount: Double?
+    public let maximumCashBackAmount: Decimal?
     
     /// Undocumented.
-    public let minimumSplitAmount: Double?
+    public let minimumSplitAmount: Decimal?
     
     /// Initializes the Amounts.
     ///
@@ -43,7 +43,7 @@ public final class Amounts: Codable {
     /// - Parameter minimumAmountToDeliver: Undocumented.
     /// - Parameter maximumCashBackAmount: Undocumented.
     /// - Parameter minimumSplitAmount: Undocumented.
-    public init(currency: String, requestedAmount: Double? = nil, cashBackAmount: Double? = nil, tipAmount: Double? = nil, paidAmount: Double? = nil, minimumAmountToDeliver: Double? = nil, maximumCashBackAmount: Double? = nil, minimumSplitAmount: Double? = nil) {
+    public init(currency: String, requestedAmount: Decimal? = nil, cashBackAmount: Decimal? = nil, tipAmount: Decimal? = nil, paidAmount: Decimal? = nil, minimumAmountToDeliver: Decimal? = nil, maximumCashBackAmount: Decimal? = nil, minimumSplitAmount: Decimal? = nil) {
         self.currency = currency
         self.requestedAmount = requestedAmount
         self.cashBackAmount = cashBackAmount

--- a/Sources/TerminalAPIKit/Models/CardAcquisitionTransaction.swift
+++ b/Sources/TerminalAPIKit/Models/CardAcquisitionTransaction.swift
@@ -25,7 +25,7 @@ public final class CardAcquisitionTransaction: Codable {
     public let forceCustomerSelectionFlag: Bool?
     
     /// Undocumented.
-    public let totalAmount: Double?
+    public let totalAmount: Decimal?
     
     /// Undocumented.
     public let paymentType: PaymentType?
@@ -43,7 +43,7 @@ public final class CardAcquisitionTransaction: Codable {
     /// - Parameter totalAmount: Undocumented.
     /// - Parameter paymentType: Undocumented.
     /// - Parameter cashBackFlag: Undocumented.
-    public init(allowedPaymentBrand: [String]? = nil, allowedLoyaltyBrand: [String]? = nil, loyaltyHandling: LoyaltyHandling? = nil, forceEntryMode: Set<ForceEntryMode>? = nil, forceCustomerSelectionFlag: Bool? = nil, totalAmount: Double? = nil, paymentType: PaymentType? = nil, cashBackFlag: Bool? = nil) {
+    public init(allowedPaymentBrand: [String]? = nil, allowedLoyaltyBrand: [String]? = nil, loyaltyHandling: LoyaltyHandling? = nil, forceEntryMode: Set<ForceEntryMode>? = nil, forceCustomerSelectionFlag: Bool? = nil, totalAmount: Decimal? = nil, paymentType: PaymentType? = nil, cashBackFlag: Bool? = nil) {
         self.allowedPaymentBrand = allowedPaymentBrand
         self.allowedLoyaltyBrand = allowedLoyaltyBrand
         self.loyaltyHandling = loyaltyHandling

--- a/Sources/TerminalAPIKit/Models/CoinsOrBills.swift
+++ b/Sources/TerminalAPIKit/Models/CoinsOrBills.swift
@@ -12,7 +12,7 @@ import Foundation
 public final class CoinsOrBills: Codable {
     
     /// Value of a coin or bill.
-    public let unitValue: Double
+    public let unitValue: Decimal
     
     /// Number of elements
     public let number: Int
@@ -21,7 +21,7 @@ public final class CoinsOrBills: Codable {
     ///
     /// - Parameter unitValue: Value of a coin or bill.
     /// - Parameter number: Number of elements
-    public init(unitValue: Double, number: Int) {
+    public init(unitValue: Decimal, number: Int) {
         self.unitValue = unitValue
         self.number = number
     }

--- a/Sources/TerminalAPIKit/Models/ConvertedAmount.swift
+++ b/Sources/TerminalAPIKit/Models/ConvertedAmount.swift
@@ -10,7 +10,7 @@ import Foundation
 public final class ConvertedAmount: Codable {
     
     /// Undocumented.
-    public let amountValue: Double
+    public let amountValue: Decimal
     
     /// Undocumented.
     public let currency: String
@@ -19,7 +19,7 @@ public final class ConvertedAmount: Codable {
     ///
     /// - Parameter amountValue: Undocumented.
     /// - Parameter currency: Undocumented.
-    public init(amountValue: Double, currency: String) {
+    public init(amountValue: Decimal, currency: String) {
         self.amountValue = amountValue
         self.currency = currency
     }

--- a/Sources/TerminalAPIKit/Models/CurrencyConversion.swift
+++ b/Sources/TerminalAPIKit/Models/CurrencyConversion.swift
@@ -18,13 +18,13 @@ public final class CurrencyConversion: Codable {
     public let convertedAmount: ConvertedAmount
     
     /// Undocumented.
-    public let rate: Double?
+    public let rate: Decimal?
     
     /// Undocumented.
-    public let markup: Double?
+    public let markup: Decimal?
     
     /// Undocumented.
-    public let commission: Double?
+    public let commission: Decimal?
     
     /// Declaration to present to the customer or the cashier for validation.
     public let declaration: String?
@@ -37,7 +37,7 @@ public final class CurrencyConversion: Codable {
     /// - Parameter markup: Undocumented.
     /// - Parameter commission: Undocumented.
     /// - Parameter declaration: Declaration to present to the customer or the cashier for validation.
-    public init(customerApprovedFlag: Bool? = nil, convertedAmount: ConvertedAmount, rate: Double? = nil, markup: Double? = nil, commission: Double? = nil, declaration: String? = nil) {
+    public init(customerApprovedFlag: Bool? = nil, convertedAmount: ConvertedAmount, rate: Decimal? = nil, markup: Decimal? = nil, commission: Decimal? = nil, declaration: String? = nil) {
         self.customerApprovedFlag = customerApprovedFlag
         self.convertedAmount = convertedAmount
         self.rate = rate

--- a/Sources/TerminalAPIKit/Models/CustomerOrder.swift
+++ b/Sources/TerminalAPIKit/Models/CustomerOrder.swift
@@ -25,10 +25,10 @@ public final class CustomerOrder: Codable {
     public let endDate: Date?
     
     /// Undocumented.
-    public let forecastedAmount: Double
+    public let forecastedAmount: Decimal
     
     /// Undocumented.
-    public let currentAmount: Double
+    public let currentAmount: Decimal
     
     /// Undocumented.
     public let currency: String?
@@ -51,7 +51,7 @@ public final class CustomerOrder: Codable {
     /// - Parameter currency: Undocumented.
     /// - Parameter accessedBy: Undocumented.
     /// - Parameter additionalInformation: Undocumented.
-    public init(customerOrderIdentifier: String? = nil, saleReferenceIdentifier: String, openOrderState: Bool? = nil, startDate: Date, endDate: Date? = nil, forecastedAmount: Double, currentAmount: Double, currency: String? = nil, accessedBy: String? = nil, additionalInformation: String? = nil) {
+    public init(customerOrderIdentifier: String? = nil, saleReferenceIdentifier: String, openOrderState: Bool? = nil, startDate: Date, endDate: Date? = nil, forecastedAmount: Decimal, currentAmount: Decimal, currency: String? = nil, accessedBy: String? = nil, additionalInformation: String? = nil) {
         self.customerOrderIdentifier = customerOrderIdentifier
         self.saleReferenceIdentifier = saleReferenceIdentifier
         self.openOrderState = openOrderState

--- a/Sources/TerminalAPIKit/Models/FinalAmounts.swift
+++ b/Sources/TerminalAPIKit/Models/FinalAmounts.swift
@@ -13,19 +13,19 @@ public final class FinalAmounts: Codable {
     public let currency: String?
     
     /// Undocumented.
-    public let authorizedAmount: Double
+    public let authorizedAmount: Decimal
     
     /// Undocumented.
-    public let totalRebatesAmount: Double?
+    public let totalRebatesAmount: Decimal?
     
     /// Undocumented.
-    public let totalFeesAmount: Double?
+    public let totalFeesAmount: Decimal?
     
     /// Undocumented.
-    public let cashBackAmount: Double?
+    public let cashBackAmount: Decimal?
     
     /// Undocumented.
-    public let tipAmount: Double?
+    public let tipAmount: Decimal?
     
     /// Initializes the FinalAmounts.
     ///
@@ -35,7 +35,7 @@ public final class FinalAmounts: Codable {
     /// - Parameter totalFeesAmount: Undocumented.
     /// - Parameter cashBackAmount: Undocumented.
     /// - Parameter tipAmount: Undocumented.
-    public init(currency: String? = nil, authorizedAmount: Double, totalRebatesAmount: Double? = nil, totalFeesAmount: Double? = nil, cashBackAmount: Double? = nil, tipAmount: Double? = nil) {
+    public init(currency: String? = nil, authorizedAmount: Decimal, totalRebatesAmount: Decimal? = nil, totalFeesAmount: Decimal? = nil, cashBackAmount: Decimal? = nil, tipAmount: Decimal? = nil) {
         self.currency = currency
         self.authorizedAmount = authorizedAmount
         self.totalRebatesAmount = totalRebatesAmount

--- a/Sources/TerminalAPIKit/Models/Instalment.swift
+++ b/Sources/TerminalAPIKit/Models/Instalment.swift
@@ -31,13 +31,13 @@ public final class Instalment: Codable {
     public let totalNbOfPayments: Int?
     
     /// Undocumented.
-    public let cumulativeAmount: Double?
+    public let cumulativeAmount: Decimal?
     
     /// Undocumented.
-    public let firstAmount: Double?
+    public let firstAmount: Decimal?
     
     /// Undocumented.
-    public let charges: Double?
+    public let charges: Decimal?
     
     /// Initializes the Instalment.
     ///
@@ -51,7 +51,7 @@ public final class Instalment: Codable {
     /// - Parameter cumulativeAmount: Undocumented.
     /// - Parameter firstAmount: Undocumented.
     /// - Parameter charges: Undocumented.
-    public init(instalmentType: InstalmentType? = nil, sequenceNumber: Int? = nil, planIdentifier: String? = nil, period: Int? = nil, periodUnit: PeriodUnit? = nil, firstPaymentDate: Date? = nil, totalNbOfPayments: Int? = nil, cumulativeAmount: Double? = nil, firstAmount: Double? = nil, charges: Double? = nil) {
+    public init(instalmentType: InstalmentType? = nil, sequenceNumber: Int? = nil, planIdentifier: String? = nil, period: Int? = nil, periodUnit: PeriodUnit? = nil, firstPaymentDate: Date? = nil, totalNbOfPayments: Int? = nil, cumulativeAmount: Decimal? = nil, firstAmount: Decimal? = nil, charges: Decimal? = nil) {
         self.instalmentType = instalmentType
         self.sequenceNumber = sequenceNumber
         self.planIdentifier = planIdentifier

--- a/Sources/TerminalAPIKit/Models/LoyaltyAccountStatus.swift
+++ b/Sources/TerminalAPIKit/Models/LoyaltyAccountStatus.swift
@@ -13,7 +13,7 @@ public final class LoyaltyAccountStatus: Codable {
     public let loyaltyAccount: LoyaltyAccount
     
     /// Undocumented.
-    public let currentBalance: Double?
+    public let currentBalance: Decimal?
     
     /// Undocumented.
     public let loyaltyUnit: LoyaltyUnit?
@@ -27,7 +27,7 @@ public final class LoyaltyAccountStatus: Codable {
     /// - Parameter currentBalance: Undocumented.
     /// - Parameter loyaltyUnit: Undocumented.
     /// - Parameter currency: Undocumented.
-    public init(loyaltyAccount: LoyaltyAccount, currentBalance: Double? = nil, loyaltyUnit: LoyaltyUnit? = nil, currency: String? = nil) {
+    public init(loyaltyAccount: LoyaltyAccount, currentBalance: Decimal? = nil, loyaltyUnit: LoyaltyUnit? = nil, currency: String? = nil) {
         self.loyaltyAccount = loyaltyAccount
         self.currentBalance = currentBalance
         self.loyaltyUnit = loyaltyUnit

--- a/Sources/TerminalAPIKit/Models/LoyaltyAmount.swift
+++ b/Sources/TerminalAPIKit/Models/LoyaltyAmount.swift
@@ -18,14 +18,14 @@ public final class LoyaltyAmount: Codable {
     public let currency: String?
     
     /// Undocumented.
-    public let amountValue: Double
+    public let amountValue: Decimal
     
     /// Initializes the LoyaltyAmount.
     ///
     /// - Parameter loyaltyUnit: Undocumented.
     /// - Parameter currency: Undocumented.
     /// - Parameter amountValue: Undocumented.
-    public init(loyaltyUnit: LoyaltyUnit? = nil, currency: String? = nil, amountValue: Double) {
+    public init(loyaltyUnit: LoyaltyUnit? = nil, currency: String? = nil, amountValue: Decimal) {
         self.loyaltyUnit = loyaltyUnit
         self.currency = currency
         self.amountValue = amountValue

--- a/Sources/TerminalAPIKit/Models/LoyaltyResult.swift
+++ b/Sources/TerminalAPIKit/Models/LoyaltyResult.swift
@@ -15,7 +15,7 @@ public final class LoyaltyResult: Codable {
     public let loyaltyAccount: LoyaltyAccount
     
     /// Balance of an account.
-    public let currentBalance: Double?
+    public let currentBalance: Decimal?
     
     /// Amount of a loyalty account.
     public let loyaltyAmount: LoyaltyAmount?
@@ -33,7 +33,7 @@ public final class LoyaltyResult: Codable {
     /// - Parameter loyaltyAmount: Amount of a loyalty account.
     /// - Parameter loyaltyAcquirerData: Data related to the loyalty Acquirer during a loyalty transaction.
     /// - Parameter rebates: Rebate form to an award;
-    public init(loyaltyAccount: LoyaltyAccount, currentBalance: Double? = nil, loyaltyAmount: LoyaltyAmount? = nil, loyaltyAcquirerData: LoyaltyAcquirerData? = nil, rebates: Rebates? = nil) {
+    public init(loyaltyAccount: LoyaltyAccount, currentBalance: Decimal? = nil, loyaltyAmount: LoyaltyAmount? = nil, loyaltyAcquirerData: LoyaltyAcquirerData? = nil, rebates: Rebates? = nil) {
         self.loyaltyAccount = loyaltyAccount
         self.currentBalance = currentBalance
         self.loyaltyAmount = loyaltyAmount

--- a/Sources/TerminalAPIKit/Models/LoyaltyTotals.swift
+++ b/Sources/TerminalAPIKit/Models/LoyaltyTotals.swift
@@ -17,14 +17,14 @@ public final class LoyaltyTotals: Codable {
     public let transactionCount: Int
     
     /// Sum of amount of processed transaction during the period.
-    public let transactionAmount: Double
+    public let transactionAmount: Decimal
     
     /// Initializes the LoyaltyTotals.
     ///
     /// - Parameter transactionType: Type of transaction for which totals are grouped.
     /// - Parameter transactionCount: Number of processed transaction during the period.
     /// - Parameter transactionAmount: Sum of amount of processed transaction during the period.
-    public init(transactionType: TransactionType, transactionCount: Int, transactionAmount: Double) {
+    public init(transactionType: TransactionType, transactionCount: Int, transactionAmount: Decimal) {
         self.transactionType = transactionType
         self.transactionCount = transactionCount
         self.transactionAmount = transactionAmount

--- a/Sources/TerminalAPIKit/Models/OriginalPOITransaction.swift
+++ b/Sources/TerminalAPIKit/Models/OriginalPOITransaction.swift
@@ -33,7 +33,7 @@ public final class OriginalPOITransaction: Codable {
     public let acquirerIdentifier: String?
     
     /// Undocumented.
-    public let amountValue: Double?
+    public let amountValue: Decimal?
     
     /// Identification of the transaction by the host in charge of the stored value transaction
     public let hostTransactionIdentifier: TransactionIdentifier?
@@ -49,7 +49,7 @@ public final class OriginalPOITransaction: Codable {
     /// - Parameter acquirerIdentifier: Undocumented.
     /// - Parameter amountValue: Undocumented.
     /// - Parameter hostTransactionIdentifier: Identification of the transaction by the host in charge of the stored value transaction
-    public init(saleIdentifier: String? = nil, poiIdentifier: String? = nil, poiTransactionIdentifier: TransactionIdentifier? = nil, reuseCardDataFlag: Bool? = nil, approvalCode: String? = nil, customerLanguage: String? = nil, acquirerIdentifier: String? = nil, amountValue: Double? = nil, hostTransactionIdentifier: TransactionIdentifier? = nil) {
+    public init(saleIdentifier: String? = nil, poiIdentifier: String? = nil, poiTransactionIdentifier: TransactionIdentifier? = nil, reuseCardDataFlag: Bool? = nil, approvalCode: String? = nil, customerLanguage: String? = nil, acquirerIdentifier: String? = nil, amountValue: Decimal? = nil, hostTransactionIdentifier: TransactionIdentifier? = nil) {
         self.saleIdentifier = saleIdentifier
         self.poiIdentifier = poiIdentifier
         self.poiTransactionIdentifier = poiTransactionIdentifier

--- a/Sources/TerminalAPIKit/Models/PaymentAccountStatus.swift
+++ b/Sources/TerminalAPIKit/Models/PaymentAccountStatus.swift
@@ -13,7 +13,7 @@ public final class PaymentAccountStatus: Codable {
     public let paymentInstrumentData: PaymentInstrumentData?
     
     /// Undocumented.
-    public let currentBalance: Double?
+    public let currentBalance: Decimal?
     
     /// Undocumented.
     public let currency: String?
@@ -27,7 +27,7 @@ public final class PaymentAccountStatus: Codable {
     /// - Parameter currentBalance: Undocumented.
     /// - Parameter currency: Undocumented.
     /// - Parameter paymentAcquirerData: Undocumented.
-    public init(paymentInstrumentData: PaymentInstrumentData? = nil, currentBalance: Double? = nil, currency: String? = nil, paymentAcquirerData: PaymentAcquirerData? = nil) {
+    public init(paymentInstrumentData: PaymentInstrumentData? = nil, currentBalance: Decimal? = nil, currency: String? = nil, paymentAcquirerData: PaymentAcquirerData? = nil) {
         self.paymentInstrumentData = paymentInstrumentData
         self.currentBalance = currentBalance
         self.currency = currency

--- a/Sources/TerminalAPIKit/Models/PaymentTotals.swift
+++ b/Sources/TerminalAPIKit/Models/PaymentTotals.swift
@@ -17,14 +17,14 @@ public final class PaymentTotals: Codable {
     public let transactionCount: Int
     
     /// Sum of amount of processed transaction during the period.
-    public let transactionAmount: Double
+    public let transactionAmount: Decimal
     
     /// Initializes the PaymentTotals.
     ///
     /// - Parameter transactionType: Type of transaction for which totals are grouped.
     /// - Parameter transactionCount: Number of processed transaction during the period.
     /// - Parameter transactionAmount: Sum of amount of processed transaction during the period.
-    public init(transactionType: TransactionType, transactionCount: Int, transactionAmount: Double) {
+    public init(transactionType: TransactionType, transactionCount: Int, transactionAmount: Decimal) {
         self.transactionType = transactionType
         self.transactionCount = transactionCount
         self.transactionAmount = transactionAmount

--- a/Sources/TerminalAPIKit/Models/PerformedTransaction.swift
+++ b/Sources/TerminalAPIKit/Models/PerformedTransaction.swift
@@ -25,7 +25,7 @@ public final class PerformedTransaction: Codable {
     public let loyaltyResult: [LoyaltyResult]?
     
     /// Undocumented.
-    public let reversedAmount: Double?
+    public let reversedAmount: Decimal?
     
     /// Initializes the PerformedTransaction.
     ///
@@ -35,7 +35,7 @@ public final class PerformedTransaction: Codable {
     /// - Parameter paymentResult: Undocumented.
     /// - Parameter loyaltyResult: Undocumented.
     /// - Parameter reversedAmount: Undocumented.
-    public init(response: MessageResponse, saleData: SaleData? = nil, poiData: POIData? = nil, paymentResult: PaymentResult? = nil, loyaltyResult: [LoyaltyResult]? = nil, reversedAmount: Double? = nil) {
+    public init(response: MessageResponse, saleData: SaleData? = nil, poiData: POIData? = nil, paymentResult: PaymentResult? = nil, loyaltyResult: [LoyaltyResult]? = nil, reversedAmount: Decimal? = nil) {
         self.response = response
         self.saleData = saleData
         self.poiData = poiData

--- a/Sources/TerminalAPIKit/Models/Rebates.swift
+++ b/Sources/TerminalAPIKit/Models/Rebates.swift
@@ -10,7 +10,7 @@ import Foundation
 public final class Rebates: Codable {
     
     /// Undocumented.
-    public let totalRebate: Double?
+    public let totalRebate: Decimal?
     
     /// Undocumented.
     public let rebateLabel: String?
@@ -23,7 +23,7 @@ public final class Rebates: Codable {
     /// - Parameter totalRebate: Undocumented.
     /// - Parameter rebateLabel: Undocumented.
     /// - Parameter saleItemRebate: Undocumented.
-    public init(totalRebate: Double? = nil, rebateLabel: String? = nil, saleItemRebate: [SaleItemRebate]? = nil) {
+    public init(totalRebate: Decimal? = nil, rebateLabel: String? = nil, saleItemRebate: [SaleItemRebate]? = nil) {
         self.totalRebate = totalRebate
         self.rebateLabel = rebateLabel
         self.saleItemRebate = saleItemRebate

--- a/Sources/TerminalAPIKit/Models/Requests/ReversalRequest.swift
+++ b/Sources/TerminalAPIKit/Models/Requests/ReversalRequest.swift
@@ -27,7 +27,7 @@ public final class ReversalRequest: Request {
     public let originalPOITransaction: OriginalPOITransaction
     
     /// Amount of the payment or loyalty to reverse..
-    public let reversedAmount: Double?
+    public let reversedAmount: Decimal?
     
     /// Reason of the payment or loyalty reversal..
     public let reversalReason: ReversalReason
@@ -42,7 +42,7 @@ public final class ReversalRequest: Request {
     /// - Parameter reversedAmount: Amount of the payment or loyalty to reverse..
     /// - Parameter reversalReason: Reason of the payment or loyalty reversal..
     /// - Parameter customerOrder: Undocumented.
-    public init(saleData: SaleData? = nil, originalPOITransaction: OriginalPOITransaction, reversedAmount: Double? = nil, reversalReason: ReversalReason, customerOrder: CustomerOrder? = nil) {
+    public init(saleData: SaleData? = nil, originalPOITransaction: OriginalPOITransaction, reversedAmount: Decimal? = nil, reversalReason: ReversalReason, customerOrder: CustomerOrder? = nil) {
         self.saleData = saleData
         self.originalPOITransaction = originalPOITransaction
         self.reversedAmount = reversedAmount

--- a/Sources/TerminalAPIKit/Models/Responses/ReversalResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/ReversalResponse.swift
@@ -24,7 +24,7 @@ public final class ReversalResponse: Response {
     public let originalPOITransaction: OriginalPOITransaction?
     
     /// Amount of the payment or loyalty to reverse..
-    public let reversedAmount: Double?
+    public let reversedAmount: Decimal?
     
     /// Undocumented.
     public let customerOrder: [CustomerOrder]?
@@ -44,7 +44,7 @@ public final class ReversalResponse: Response {
         response: MessageResponse,
         poiData: POIData? = nil,
         originalPOITransaction: OriginalPOITransaction? = nil,
-        reversedAmount: Double? = nil,
+        reversedAmount: Decimal? = nil,
         customerOrder: [CustomerOrder]? = nil,
         paymentReceipt: [PaymentReceipt]? = nil
     ) {

--- a/Sources/TerminalAPIKit/Models/SaleItem.swift
+++ b/Sources/TerminalAPIKit/Models/SaleItem.swift
@@ -24,13 +24,13 @@ public final class SaleItem: Codable {
     public let unitOfMeasure: UnitOfMeasure?
     
     /// Product quantity
-    public let quantity: Double?
+    public let quantity: Decimal?
     
     /// Price per unit of product
-    public let unitPrice: Double?
+    public let unitPrice: Decimal?
     
     /// Total amount of the item line.
-    public let itemAmount: Double
+    public let itemAmount: Decimal
     
     /// Type of taxes associated to the line item.
     public let taxCode: String?
@@ -57,7 +57,7 @@ public final class SaleItem: Codable {
     /// - Parameter saleChannel: Commercial or distribution channel associated to the line item.
     /// - Parameter productLabel: Undocumented.
     /// - Parameter additionalProductInfo: Additionl information related to the line item.
-    public init(itemIdentifier: Int, productCode: String, eanUpc: String? = nil, unitOfMeasure: UnitOfMeasure? = nil, quantity: Double? = nil, unitPrice: Double? = nil, itemAmount: Double, taxCode: String? = nil, saleChannel: String? = nil, productLabel: String? = nil, additionalProductInfo: String? = nil) {
+    public init(itemIdentifier: Int, productCode: String, eanUpc: String? = nil, unitOfMeasure: UnitOfMeasure? = nil, quantity: Decimal? = nil, unitPrice: Decimal? = nil, itemAmount: Decimal, taxCode: String? = nil, saleChannel: String? = nil, productLabel: String? = nil, additionalProductInfo: String? = nil) {
         self.itemIdentifier = itemIdentifier
         self.productCode = productCode
         self.eanUpc = eanUpc

--- a/Sources/TerminalAPIKit/Models/SaleItemRebate.swift
+++ b/Sources/TerminalAPIKit/Models/SaleItemRebate.swift
@@ -24,10 +24,10 @@ public final class SaleItemRebate: Codable {
     public let unitOfMeasure: UnitOfMeasure?
     
     /// Product quantity
-    public let quantity: Double?
+    public let quantity: Decimal?
     
     /// Total amount of the item line.
-    public let itemAmount: Double?
+    public let itemAmount: Decimal?
     
     /// Short text to qualify a rebate on an line item.
     public let rebateLabel: String?
@@ -41,7 +41,7 @@ public final class SaleItemRebate: Codable {
     /// - Parameter quantity: Product quantity
     /// - Parameter itemAmount: Total amount of the item line.
     /// - Parameter rebateLabel: Short text to qualify a rebate on an line item.
-    public init(itemIdentifier: Int, productCode: String, eanUpc: String? = nil, unitOfMeasure: UnitOfMeasure? = nil, quantity: Double? = nil, itemAmount: Double? = nil, rebateLabel: String? = nil) {
+    public init(itemIdentifier: Int, productCode: String, eanUpc: String? = nil, unitOfMeasure: UnitOfMeasure? = nil, quantity: Decimal? = nil, itemAmount: Decimal? = nil, rebateLabel: String? = nil) {
         self.itemIdentifier = itemIdentifier
         self.productCode = productCode
         self.eanUpc = eanUpc

--- a/Sources/TerminalAPIKit/Models/StoredValueData.swift
+++ b/Sources/TerminalAPIKit/Models/StoredValueData.swift
@@ -30,7 +30,7 @@ public final class StoredValueData: Codable {
     public let eanUpc: String?
     
     /// Total amount of the item line.
-    public let itemAmount: Double?
+    public let itemAmount: Decimal?
     
     /// Currency of a monetary amount.
     public let currency: String?
@@ -45,7 +45,7 @@ public final class StoredValueData: Codable {
     /// - Parameter eanUpc: Standard product code of item purchased with the transaction.
     /// - Parameter itemAmount: Total amount of the item line.
     /// - Parameter currency: Currency of a monetary amount.
-    public init(storedValueProvider: String? = nil, storedValueTransactionType: StoredValueTransactionType, storedValueAccountIdentifier: StoredValueAccountIdentifier? = nil, originalPOITransaction: OriginalPOITransaction? = nil, productCode: String? = nil, eanUpc: String? = nil, itemAmount: Double? = nil, currency: String? = nil) {
+    public init(storedValueProvider: String? = nil, storedValueTransactionType: StoredValueTransactionType, storedValueAccountIdentifier: StoredValueAccountIdentifier? = nil, originalPOITransaction: OriginalPOITransaction? = nil, productCode: String? = nil, eanUpc: String? = nil, itemAmount: Decimal? = nil, currency: String? = nil) {
         self.storedValueProvider = storedValueProvider
         self.storedValueTransactionType = storedValueTransactionType
         self.storedValueAccountIdentifier = storedValueAccountIdentifier

--- a/Sources/TerminalAPIKit/Models/StoredValueResult.swift
+++ b/Sources/TerminalAPIKit/Models/StoredValueResult.swift
@@ -21,7 +21,7 @@ public final class StoredValueResult: Codable {
     public let eanUpc: String?
     
     /// Total amount of the item line.
-    public let itemAmount: Double?
+    public let itemAmount: Decimal?
     
     /// Currency of a monetary amount.
     public let currency: String?
@@ -37,7 +37,7 @@ public final class StoredValueResult: Codable {
     /// - Parameter itemAmount: Total amount of the item line.
     /// - Parameter currency: Currency of a monetary amount.
     /// - Parameter storedValueAccountStatus: Data related to the result of the stored value card transaction.
-    public init(storedValueTransactionType: StoredValueTransactionType, productCode: String? = nil, eanUpc: String? = nil, itemAmount: Double? = nil, currency: String? = nil, storedValueAccountStatus: StoredValueAccountStatus? = nil) {
+    public init(storedValueTransactionType: StoredValueTransactionType, productCode: String? = nil, eanUpc: String? = nil, itemAmount: Decimal? = nil, currency: String? = nil, storedValueAccountStatus: StoredValueAccountStatus? = nil) {
         self.storedValueTransactionType = storedValueTransactionType
         self.productCode = productCode
         self.eanUpc = eanUpc


### PR DESCRIPTION
This PR replaces use of `Double` with `Decimal` when working with monetary values.