### PR TITLE
Update version to 2.0.0

### DIFF
--- a/TerminalAPIKit.podspec
+++ b/TerminalAPIKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'TerminalAPIKit'
-  s.version = '1.3.0'
+  s.version = '2.0.0'
   s.summary = "Adyen Terminal API for iOS"
   s.description = <<-DESC
     TerminalAPIKit for iOS helps with integrating Adyen's Terminal API into your iOS POS app.


### PR DESCRIPTION
This PR updates sets the package version to 2.0.0

## Release 2.0.0 brings the following changes:
### Added:
- Helper functions for [deriving the key](https://github.com/Adyen/adyen-terminal-api-ios#derive-the-encryption-key) used to encrypt the communication when using for local TAPI integration.
- Documentation regarding [local TAPI integration](https://github.com/Adyen/adyen-terminal-api-ios#local-terminal-api-integration).
- Support for decoding `ISO8601` dates without optional milliseconds.

### Changed:
- Changed any numeric amount type from `Double` to `Decimal`.
