### PR TITLE
Release 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Adyen Terminal API for iOS
 
-**TerminalAPIKit** for iOS helps with integrating Adyen's [Terminal API](https://docs.adyen.com/point-of-sale/terminal-api) into your iOS POS app. The kit provides the models to create a Terminal API `SaletoPOIRequest`, and to decode the received `SaletoPOIResponse`.
+**TerminalAPIKit** for iOS helps with integrating Adyen's [Terminal API](https://docs.adyen.com/point-of-sale/terminal-api) into your iOS POS app. The kit provides the models to create a Terminal API `SaletoPOIRequest`, and to decode the received `SaletoPOIResponse`. For local Terminal API integrations, the kit also helps with protecting local communications.
+
+This package is intended to be used in the following scenarios:
+- when integrating POS Mobile SDK.
+- when integrating client-side with an Adyen terminal using local Terminal API.
+- when integrating server-side with an Adyen terminal using cloud Terminal API.
 
 ## Install TerminalAPIKit
 TerminalAPIKit for iOS is available through [Swift Package Manager](https://swift.org/package-manager/). 
@@ -13,10 +18,10 @@ To install the kit:
 
 For detailed instructions see [Adding Package Dependencies to Your App](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app).
 
-## Use TerminalAPIKit
+## Create Terminal API requests
 The next sections describe how to create a request and how to decode the response.
 
-### Create a request
+### Create a payment request
 To create a Terminal API `SaleToPOIRequest` for making a payment:
 
 1. Create an instance of `MessageHeader`, representing the [MessageHeader](https://docs.adyen.com/point-of-sale/terminal-api/terminal-api-reference#comadyennexomessageheader) of your Terminal API request.
@@ -76,6 +81,51 @@ To handle the response:
 2. After decoding, note the following:
    - The message object has a type of `Message<PaymentResponse>`, representing the Terminal API [SaleToPOIResponse](https://docs.adyen.com/point-of-sale/terminal-api-fundamentals#responses). 
    - The `header` and `body` properties of the `message` represent the [MessageHeader](https://docs.adyen.com/point-of-sale/terminal-api/terminal-api-reference#comadyennexomessageheader) and [PaymentResponse](https://docs.adyen.com/point-of-sale/terminal-api/terminal-api-reference#comadyennexopaymentresponse) body.
+   
+## Local Terminal API integration
+
+If your integration uses local communications, you need to protect your integration against man-in-the-middle attacks, eavesdropping, and tampering. To protect communications, you need to:
+- Validate the certificate of the payment terminal, to confirm your POS app is communicating directly with an Adyen-supplied terminal.
+- Encrypt communications. This prevents intruders from reading the messages transmitted between the POS app and the terminal.
+ 
+To help you with this, TerminalAPIKit provides helper functions to:
+- Derive the encryption key from the [shared key set up in your Adyen Customer Area](https://docs.adyen.com/point-of-sale/choose-your-architecture/local#set-up-shared-key). 
+- Encrypt and decrypt the messages passed between your terminal and your iOS or macOS POS application.
+
+### Derive the encryption key
+To derive the key used for encrypting and decrypting local communications between the terminal and your POS app:
+
+1. Get the `identifier`, `passphrase`, and `version` of the shared key: <br>
+   In the Adyen Customer Area, under **Point of sale**, go to the terminal settings for your merchant account or store. 
+   Select **Integrations** and under **Terminal API** go to **Encryption key**. 
+   To see the key identifier, passphrase, and version values, select **Decrypted**.
+
+2. Derive the key, making sure to pass the values in string form exactly as they appear in the Customer Area.
+   ```swift
+   let encryptionKey = try EncryptionKey(
+       identifier: "KEY_IDENTIFIER",
+       passphrase: "KEY_PASSPHRASE",
+       version: KEY_VERSION
+   )
+   ```
+Once the key is derived, you are ready to encrypt your local communications.
+
+### Encrypt and decrypt communications
+1. Create your request as described above. For example, create a `Message<PaymentRequest>`.
+2. Encrypt your request.
+   ```swift
+   let encryptionKey: EncryptionKey = // the key you derived earlier
+   let request: Message<PaymentRequest> = // the payment request you created
+   let encryptedMessage: Data = try request.encrypt(using: encryptionKey)
+   ```
+3. Send the `encryptedMessage` to the terminal.
+4. When you receive the response from the terminal, decrypt the response.
+   ```swift
+   let key: EncryptionKey = // the key you derived earlier
+   let response: Data = // the response you receive from the terminal
+   let encryptedMessage: EncryptedMessage = try Coder.decode(EncryptedMessage.self, from: response)
+   let decryptedMessage: Message<PaymentResponse> = try decrypt(PaymentResponse.self, using: key)
+   ```
 
 ## Requirements
 To use TerminalAPIKit for iOS, you need:

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ To use TerminalAPIKit for iOS, you need:
 - Swift 5.6
 
 ## Support
-If you have a feature request, or spotted a bug or a technical problem, create a GitHub issue. For other questions, contact our [support team](https://support.adyen.com/hc/en-us/requests/new?ticket_form_id=360000705420).
+If you have a feature request, or spotted a bug or a technical problem, create a GitHub issue. For other questions, contact our [support team](https://ca-live.adyen.com/ca/ca/contactUs/support.shtml).
 
 ## Contributing
 We strongly encourage you to join us in contributing to this repository so everyone can benefit from:

--- a/Sources/TerminalAPIKit/EncryptedMesssage/EncryptionKey.swift
+++ b/Sources/TerminalAPIKit/EncryptedMesssage/EncryptionKey.swift
@@ -6,6 +6,15 @@
 //
 
 import Foundation
+import CommonCrypto
+
+/// Describes errors that can happen during der
+public struct KeyDerivationError: Error {
+    
+    /// The result code of the failed key derivation.
+    public let errorCode: CCStatus
+    
+}
 
 /// A key used to encrypt and decrypt messages.
 public struct EncryptionKey {
@@ -31,6 +40,34 @@ public struct EncryptionKey {
         self.identifier = identifier
         self.version = version
         self.data = data
+    }
+    
+    // MARK: - Key derivation
+    
+    /// Derives a key from given passhprage, identifier and version.
+    ///
+    /// The `passphrase`, `identifier` and `version` can be found in the terminal settings in the Customer Area,
+    /// under Integrations -> Terminal API -> Encryption key. Pass them in a string form, exactly as they appear.
+    ///
+    /// - Parameters:
+    ///   - passphrase: The passphrase of the key.
+    ///   - identifier: The identifier of the key.
+    ///   - version: The version of the key.
+    ///
+    /// - Throws: ``KeyDerivationError`` if key derivation was unsuccessful.
+    public init(
+        passphrase: String,
+        identifier: String,
+        version: UInt
+    ) throws {
+        let keyData = try Self.pbkdf2SHA1(
+            passphrase: passphrase,
+            salt: Data(Self.saltphrase.utf8),
+            keyByteCount: Self.keyLength,
+            rounds: Self.keyDerivationPasses
+        )
+        
+        self.init(identifier: identifier, version: version, data: keyData)
     }
     
     // MARK: - Key Slices
@@ -74,6 +111,39 @@ public struct EncryptionKey {
     
     private var initializationVectorRange: Range<Int> {
         return aesKeyRange.upperBound..<aesKeyRange.upperBound + EncryptionKey.initializationVectorLength
+    }
+    
+    private static let saltphrase = "AdyenNexoV1Salt"
+    private static let keyLength = 80
+    private static let keyDerivationPasses = 4000
+    
+    private static func pbkdf2SHA1(
+        passphrase: String,
+        salt: Data,
+        keyByteCount: Int,
+        rounds: Int
+    ) throws -> Data {
+        
+        let passphraseData = Data(passphrase.utf8)
+        var derivedKeyData: [UInt8] = .init(repeating: 0, count: keyByteCount)
+        
+        let derivationStatus = CCKeyDerivationPBKDF(
+            CCPBKDFAlgorithm(kCCPBKDF2),
+            passphrase,
+            passphraseData.count,
+            salt.bytes,
+            salt.count,
+            CCPBKDFAlgorithm(kCCPRFHmacAlgSHA1),
+            UInt32(rounds),
+            &derivedKeyData,
+            derivedKeyData.count
+        )
+        
+        guard derivationStatus == 0 else {
+            throw KeyDerivationError(errorCode: derivationStatus)
+        }
+        
+        return Data(derivedKeyData)
     }
     
 }

--- a/Sources/TerminalAPIKit/Models/Amounts.swift
+++ b/Sources/TerminalAPIKit/Models/Amounts.swift
@@ -13,25 +13,25 @@ public final class Amounts: Codable {
     public let currency: String
     
     /// Undocumented.
-    public let requestedAmount: Double?
+    public let requestedAmount: Decimal?
     
     /// Undocumented.
-    public let cashBackAmount: Double?
+    public let cashBackAmount: Decimal?
     
     /// Undocumented.
-    public let tipAmount: Double?
+    public let tipAmount: Decimal?
     
     /// Undocumented.
-    public let paidAmount: Double?
+    public let paidAmount: Decimal?
     
     /// Undocumented.
-    public let minimumAmountToDeliver: Double?
+    public let minimumAmountToDeliver: Decimal?
     
     /// Undocumented.
-    public let maximumCashBackAmount: Double?
+    public let maximumCashBackAmount: Decimal?
     
     /// Undocumented.
-    public let minimumSplitAmount: Double?
+    public let minimumSplitAmount: Decimal?
     
     /// Initializes the Amounts.
     ///
@@ -43,7 +43,7 @@ public final class Amounts: Codable {
     /// - Parameter minimumAmountToDeliver: Undocumented.
     /// - Parameter maximumCashBackAmount: Undocumented.
     /// - Parameter minimumSplitAmount: Undocumented.
-    public init(currency: String, requestedAmount: Double? = nil, cashBackAmount: Double? = nil, tipAmount: Double? = nil, paidAmount: Double? = nil, minimumAmountToDeliver: Double? = nil, maximumCashBackAmount: Double? = nil, minimumSplitAmount: Double? = nil) {
+    public init(currency: String, requestedAmount: Decimal? = nil, cashBackAmount: Decimal? = nil, tipAmount: Decimal? = nil, paidAmount: Decimal? = nil, minimumAmountToDeliver: Decimal? = nil, maximumCashBackAmount: Decimal? = nil, minimumSplitAmount: Decimal? = nil) {
         self.currency = currency
         self.requestedAmount = requestedAmount
         self.cashBackAmount = cashBackAmount

--- a/Sources/TerminalAPIKit/Models/CardAcquisitionTransaction.swift
+++ b/Sources/TerminalAPIKit/Models/CardAcquisitionTransaction.swift
@@ -25,7 +25,7 @@ public final class CardAcquisitionTransaction: Codable {
     public let forceCustomerSelectionFlag: Bool?
     
     /// Undocumented.
-    public let totalAmount: Double?
+    public let totalAmount: Decimal?
     
     /// Undocumented.
     public let paymentType: PaymentType?
@@ -43,7 +43,7 @@ public final class CardAcquisitionTransaction: Codable {
     /// - Parameter totalAmount: Undocumented.
     /// - Parameter paymentType: Undocumented.
     /// - Parameter cashBackFlag: Undocumented.
-    public init(allowedPaymentBrand: [String]? = nil, allowedLoyaltyBrand: [String]? = nil, loyaltyHandling: LoyaltyHandling? = nil, forceEntryMode: Set<ForceEntryMode>? = nil, forceCustomerSelectionFlag: Bool? = nil, totalAmount: Double? = nil, paymentType: PaymentType? = nil, cashBackFlag: Bool? = nil) {
+    public init(allowedPaymentBrand: [String]? = nil, allowedLoyaltyBrand: [String]? = nil, loyaltyHandling: LoyaltyHandling? = nil, forceEntryMode: Set<ForceEntryMode>? = nil, forceCustomerSelectionFlag: Bool? = nil, totalAmount: Decimal? = nil, paymentType: PaymentType? = nil, cashBackFlag: Bool? = nil) {
         self.allowedPaymentBrand = allowedPaymentBrand
         self.allowedLoyaltyBrand = allowedLoyaltyBrand
         self.loyaltyHandling = loyaltyHandling

--- a/Sources/TerminalAPIKit/Models/CoinsOrBills.swift
+++ b/Sources/TerminalAPIKit/Models/CoinsOrBills.swift
@@ -12,7 +12,7 @@ import Foundation
 public final class CoinsOrBills: Codable {
     
     /// Value of a coin or bill.
-    public let unitValue: Double
+    public let unitValue: Decimal
     
     /// Number of elements
     public let number: Int
@@ -21,7 +21,7 @@ public final class CoinsOrBills: Codable {
     ///
     /// - Parameter unitValue: Value of a coin or bill.
     /// - Parameter number: Number of elements
-    public init(unitValue: Double, number: Int) {
+    public init(unitValue: Decimal, number: Int) {
         self.unitValue = unitValue
         self.number = number
     }

--- a/Sources/TerminalAPIKit/Models/ConvertedAmount.swift
+++ b/Sources/TerminalAPIKit/Models/ConvertedAmount.swift
@@ -10,7 +10,7 @@ import Foundation
 public final class ConvertedAmount: Codable {
     
     /// Undocumented.
-    public let amountValue: Double
+    public let amountValue: Decimal
     
     /// Undocumented.
     public let currency: String
@@ -19,7 +19,7 @@ public final class ConvertedAmount: Codable {
     ///
     /// - Parameter amountValue: Undocumented.
     /// - Parameter currency: Undocumented.
-    public init(amountValue: Double, currency: String) {
+    public init(amountValue: Decimal, currency: String) {
         self.amountValue = amountValue
         self.currency = currency
     }

--- a/Sources/TerminalAPIKit/Models/CurrencyConversion.swift
+++ b/Sources/TerminalAPIKit/Models/CurrencyConversion.swift
@@ -18,13 +18,13 @@ public final class CurrencyConversion: Codable {
     public let convertedAmount: ConvertedAmount
     
     /// Undocumented.
-    public let rate: Double?
+    public let rate: Decimal?
     
     /// Undocumented.
-    public let markup: Double?
+    public let markup: Decimal?
     
     /// Undocumented.
-    public let commission: Double?
+    public let commission: Decimal?
     
     /// Declaration to present to the customer or the cashier for validation.
     public let declaration: String?
@@ -37,7 +37,7 @@ public final class CurrencyConversion: Codable {
     /// - Parameter markup: Undocumented.
     /// - Parameter commission: Undocumented.
     /// - Parameter declaration: Declaration to present to the customer or the cashier for validation.
-    public init(customerApprovedFlag: Bool? = nil, convertedAmount: ConvertedAmount, rate: Double? = nil, markup: Double? = nil, commission: Double? = nil, declaration: String? = nil) {
+    public init(customerApprovedFlag: Bool? = nil, convertedAmount: ConvertedAmount, rate: Decimal? = nil, markup: Decimal? = nil, commission: Decimal? = nil, declaration: String? = nil) {
         self.customerApprovedFlag = customerApprovedFlag
         self.convertedAmount = convertedAmount
         self.rate = rate

--- a/Sources/TerminalAPIKit/Models/CustomerOrder.swift
+++ b/Sources/TerminalAPIKit/Models/CustomerOrder.swift
@@ -25,10 +25,10 @@ public final class CustomerOrder: Codable {
     public let endDate: Date?
     
     /// Undocumented.
-    public let forecastedAmount: Double
+    public let forecastedAmount: Decimal
     
     /// Undocumented.
-    public let currentAmount: Double
+    public let currentAmount: Decimal
     
     /// Undocumented.
     public let currency: String?
@@ -51,7 +51,7 @@ public final class CustomerOrder: Codable {
     /// - Parameter currency: Undocumented.
     /// - Parameter accessedBy: Undocumented.
     /// - Parameter additionalInformation: Undocumented.
-    public init(customerOrderIdentifier: String? = nil, saleReferenceIdentifier: String, openOrderState: Bool? = nil, startDate: Date, endDate: Date? = nil, forecastedAmount: Double, currentAmount: Double, currency: String? = nil, accessedBy: String? = nil, additionalInformation: String? = nil) {
+    public init(customerOrderIdentifier: String? = nil, saleReferenceIdentifier: String, openOrderState: Bool? = nil, startDate: Date, endDate: Date? = nil, forecastedAmount: Decimal, currentAmount: Decimal, currency: String? = nil, accessedBy: String? = nil, additionalInformation: String? = nil) {
         self.customerOrderIdentifier = customerOrderIdentifier
         self.saleReferenceIdentifier = saleReferenceIdentifier
         self.openOrderState = openOrderState

--- a/Sources/TerminalAPIKit/Models/FinalAmounts.swift
+++ b/Sources/TerminalAPIKit/Models/FinalAmounts.swift
@@ -13,19 +13,19 @@ public final class FinalAmounts: Codable {
     public let currency: String?
     
     /// Undocumented.
-    public let authorizedAmount: Double
+    public let authorizedAmount: Decimal
     
     /// Undocumented.
-    public let totalRebatesAmount: Double?
+    public let totalRebatesAmount: Decimal?
     
     /// Undocumented.
-    public let totalFeesAmount: Double?
+    public let totalFeesAmount: Decimal?
     
     /// Undocumented.
-    public let cashBackAmount: Double?
+    public let cashBackAmount: Decimal?
     
     /// Undocumented.
-    public let tipAmount: Double?
+    public let tipAmount: Decimal?
     
     /// Initializes the FinalAmounts.
     ///
@@ -35,7 +35,7 @@ public final class FinalAmounts: Codable {
     /// - Parameter totalFeesAmount: Undocumented.
     /// - Parameter cashBackAmount: Undocumented.
     /// - Parameter tipAmount: Undocumented.
-    public init(currency: String? = nil, authorizedAmount: Double, totalRebatesAmount: Double? = nil, totalFeesAmount: Double? = nil, cashBackAmount: Double? = nil, tipAmount: Double? = nil) {
+    public init(currency: String? = nil, authorizedAmount: Decimal, totalRebatesAmount: Decimal? = nil, totalFeesAmount: Decimal? = nil, cashBackAmount: Decimal? = nil, tipAmount: Decimal? = nil) {
         self.currency = currency
         self.authorizedAmount = authorizedAmount
         self.totalRebatesAmount = totalRebatesAmount

--- a/Sources/TerminalAPIKit/Models/Instalment.swift
+++ b/Sources/TerminalAPIKit/Models/Instalment.swift
@@ -31,13 +31,13 @@ public final class Instalment: Codable {
     public let totalNbOfPayments: Int?
     
     /// Undocumented.
-    public let cumulativeAmount: Double?
+    public let cumulativeAmount: Decimal?
     
     /// Undocumented.
-    public let firstAmount: Double?
+    public let firstAmount: Decimal?
     
     /// Undocumented.
-    public let charges: Double?
+    public let charges: Decimal?
     
     /// Initializes the Instalment.
     ///
@@ -51,7 +51,7 @@ public final class Instalment: Codable {
     /// - Parameter cumulativeAmount: Undocumented.
     /// - Parameter firstAmount: Undocumented.
     /// - Parameter charges: Undocumented.
-    public init(instalmentType: InstalmentType? = nil, sequenceNumber: Int? = nil, planIdentifier: String? = nil, period: Int? = nil, periodUnit: PeriodUnit? = nil, firstPaymentDate: Date? = nil, totalNbOfPayments: Int? = nil, cumulativeAmount: Double? = nil, firstAmount: Double? = nil, charges: Double? = nil) {
+    public init(instalmentType: InstalmentType? = nil, sequenceNumber: Int? = nil, planIdentifier: String? = nil, period: Int? = nil, periodUnit: PeriodUnit? = nil, firstPaymentDate: Date? = nil, totalNbOfPayments: Int? = nil, cumulativeAmount: Decimal? = nil, firstAmount: Decimal? = nil, charges: Decimal? = nil) {
         self.instalmentType = instalmentType
         self.sequenceNumber = sequenceNumber
         self.planIdentifier = planIdentifier

--- a/Sources/TerminalAPIKit/Models/LoyaltyAccountStatus.swift
+++ b/Sources/TerminalAPIKit/Models/LoyaltyAccountStatus.swift
@@ -13,7 +13,7 @@ public final class LoyaltyAccountStatus: Codable {
     public let loyaltyAccount: LoyaltyAccount
     
     /// Undocumented.
-    public let currentBalance: Double?
+    public let currentBalance: Decimal?
     
     /// Undocumented.
     public let loyaltyUnit: LoyaltyUnit?
@@ -27,7 +27,7 @@ public final class LoyaltyAccountStatus: Codable {
     /// - Parameter currentBalance: Undocumented.
     /// - Parameter loyaltyUnit: Undocumented.
     /// - Parameter currency: Undocumented.
-    public init(loyaltyAccount: LoyaltyAccount, currentBalance: Double? = nil, loyaltyUnit: LoyaltyUnit? = nil, currency: String? = nil) {
+    public init(loyaltyAccount: LoyaltyAccount, currentBalance: Decimal? = nil, loyaltyUnit: LoyaltyUnit? = nil, currency: String? = nil) {
         self.loyaltyAccount = loyaltyAccount
         self.currentBalance = currentBalance
         self.loyaltyUnit = loyaltyUnit

--- a/Sources/TerminalAPIKit/Models/LoyaltyAmount.swift
+++ b/Sources/TerminalAPIKit/Models/LoyaltyAmount.swift
@@ -18,14 +18,14 @@ public final class LoyaltyAmount: Codable {
     public let currency: String?
     
     /// Undocumented.
-    public let amountValue: Double
+    public let amountValue: Decimal
     
     /// Initializes the LoyaltyAmount.
     ///
     /// - Parameter loyaltyUnit: Undocumented.
     /// - Parameter currency: Undocumented.
     /// - Parameter amountValue: Undocumented.
-    public init(loyaltyUnit: LoyaltyUnit? = nil, currency: String? = nil, amountValue: Double) {
+    public init(loyaltyUnit: LoyaltyUnit? = nil, currency: String? = nil, amountValue: Decimal) {
         self.loyaltyUnit = loyaltyUnit
         self.currency = currency
         self.amountValue = amountValue

--- a/Sources/TerminalAPIKit/Models/LoyaltyResult.swift
+++ b/Sources/TerminalAPIKit/Models/LoyaltyResult.swift
@@ -15,7 +15,7 @@ public final class LoyaltyResult: Codable {
     public let loyaltyAccount: LoyaltyAccount
     
     /// Balance of an account.
-    public let currentBalance: Double?
+    public let currentBalance: Decimal?
     
     /// Amount of a loyalty account.
     public let loyaltyAmount: LoyaltyAmount?
@@ -33,7 +33,7 @@ public final class LoyaltyResult: Codable {
     /// - Parameter loyaltyAmount: Amount of a loyalty account.
     /// - Parameter loyaltyAcquirerData: Data related to the loyalty Acquirer during a loyalty transaction.
     /// - Parameter rebates: Rebate form to an award;
-    public init(loyaltyAccount: LoyaltyAccount, currentBalance: Double? = nil, loyaltyAmount: LoyaltyAmount? = nil, loyaltyAcquirerData: LoyaltyAcquirerData? = nil, rebates: Rebates? = nil) {
+    public init(loyaltyAccount: LoyaltyAccount, currentBalance: Decimal? = nil, loyaltyAmount: LoyaltyAmount? = nil, loyaltyAcquirerData: LoyaltyAcquirerData? = nil, rebates: Rebates? = nil) {
         self.loyaltyAccount = loyaltyAccount
         self.currentBalance = currentBalance
         self.loyaltyAmount = loyaltyAmount

--- a/Sources/TerminalAPIKit/Models/LoyaltyTotals.swift
+++ b/Sources/TerminalAPIKit/Models/LoyaltyTotals.swift
@@ -17,14 +17,14 @@ public final class LoyaltyTotals: Codable {
     public let transactionCount: Int
     
     /// Sum of amount of processed transaction during the period.
-    public let transactionAmount: Double
+    public let transactionAmount: Decimal
     
     /// Initializes the LoyaltyTotals.
     ///
     /// - Parameter transactionType: Type of transaction for which totals are grouped.
     /// - Parameter transactionCount: Number of processed transaction during the period.
     /// - Parameter transactionAmount: Sum of amount of processed transaction during the period.
-    public init(transactionType: TransactionType, transactionCount: Int, transactionAmount: Double) {
+    public init(transactionType: TransactionType, transactionCount: Int, transactionAmount: Decimal) {
         self.transactionType = transactionType
         self.transactionCount = transactionCount
         self.transactionAmount = transactionAmount

--- a/Sources/TerminalAPIKit/Models/OriginalPOITransaction.swift
+++ b/Sources/TerminalAPIKit/Models/OriginalPOITransaction.swift
@@ -33,7 +33,7 @@ public final class OriginalPOITransaction: Codable {
     public let acquirerIdentifier: String?
     
     /// Undocumented.
-    public let amountValue: Double?
+    public let amountValue: Decimal?
     
     /// Identification of the transaction by the host in charge of the stored value transaction
     public let hostTransactionIdentifier: TransactionIdentifier?
@@ -49,7 +49,7 @@ public final class OriginalPOITransaction: Codable {
     /// - Parameter acquirerIdentifier: Undocumented.
     /// - Parameter amountValue: Undocumented.
     /// - Parameter hostTransactionIdentifier: Identification of the transaction by the host in charge of the stored value transaction
-    public init(saleIdentifier: String? = nil, poiIdentifier: String? = nil, poiTransactionIdentifier: TransactionIdentifier? = nil, reuseCardDataFlag: Bool? = nil, approvalCode: String? = nil, customerLanguage: String? = nil, acquirerIdentifier: String? = nil, amountValue: Double? = nil, hostTransactionIdentifier: TransactionIdentifier? = nil) {
+    public init(saleIdentifier: String? = nil, poiIdentifier: String? = nil, poiTransactionIdentifier: TransactionIdentifier? = nil, reuseCardDataFlag: Bool? = nil, approvalCode: String? = nil, customerLanguage: String? = nil, acquirerIdentifier: String? = nil, amountValue: Decimal? = nil, hostTransactionIdentifier: TransactionIdentifier? = nil) {
         self.saleIdentifier = saleIdentifier
         self.poiIdentifier = poiIdentifier
         self.poiTransactionIdentifier = poiTransactionIdentifier

--- a/Sources/TerminalAPIKit/Models/PaymentAccountStatus.swift
+++ b/Sources/TerminalAPIKit/Models/PaymentAccountStatus.swift
@@ -13,7 +13,7 @@ public final class PaymentAccountStatus: Codable {
     public let paymentInstrumentData: PaymentInstrumentData?
     
     /// Undocumented.
-    public let currentBalance: Double?
+    public let currentBalance: Decimal?
     
     /// Undocumented.
     public let currency: String?
@@ -27,7 +27,7 @@ public final class PaymentAccountStatus: Codable {
     /// - Parameter currentBalance: Undocumented.
     /// - Parameter currency: Undocumented.
     /// - Parameter paymentAcquirerData: Undocumented.
-    public init(paymentInstrumentData: PaymentInstrumentData? = nil, currentBalance: Double? = nil, currency: String? = nil, paymentAcquirerData: PaymentAcquirerData? = nil) {
+    public init(paymentInstrumentData: PaymentInstrumentData? = nil, currentBalance: Decimal? = nil, currency: String? = nil, paymentAcquirerData: PaymentAcquirerData? = nil) {
         self.paymentInstrumentData = paymentInstrumentData
         self.currentBalance = currentBalance
         self.currency = currency

--- a/Sources/TerminalAPIKit/Models/PaymentTotals.swift
+++ b/Sources/TerminalAPIKit/Models/PaymentTotals.swift
@@ -17,14 +17,14 @@ public final class PaymentTotals: Codable {
     public let transactionCount: Int
     
     /// Sum of amount of processed transaction during the period.
-    public let transactionAmount: Double
+    public let transactionAmount: Decimal
     
     /// Initializes the PaymentTotals.
     ///
     /// - Parameter transactionType: Type of transaction for which totals are grouped.
     /// - Parameter transactionCount: Number of processed transaction during the period.
     /// - Parameter transactionAmount: Sum of amount of processed transaction during the period.
-    public init(transactionType: TransactionType, transactionCount: Int, transactionAmount: Double) {
+    public init(transactionType: TransactionType, transactionCount: Int, transactionAmount: Decimal) {
         self.transactionType = transactionType
         self.transactionCount = transactionCount
         self.transactionAmount = transactionAmount

--- a/Sources/TerminalAPIKit/Models/PerformedTransaction.swift
+++ b/Sources/TerminalAPIKit/Models/PerformedTransaction.swift
@@ -25,7 +25,7 @@ public final class PerformedTransaction: Codable {
     public let loyaltyResult: [LoyaltyResult]?
     
     /// Undocumented.
-    public let reversedAmount: Double?
+    public let reversedAmount: Decimal?
     
     /// Initializes the PerformedTransaction.
     ///
@@ -35,7 +35,7 @@ public final class PerformedTransaction: Codable {
     /// - Parameter paymentResult: Undocumented.
     /// - Parameter loyaltyResult: Undocumented.
     /// - Parameter reversedAmount: Undocumented.
-    public init(response: MessageResponse, saleData: SaleData? = nil, poiData: POIData? = nil, paymentResult: PaymentResult? = nil, loyaltyResult: [LoyaltyResult]? = nil, reversedAmount: Double? = nil) {
+    public init(response: MessageResponse, saleData: SaleData? = nil, poiData: POIData? = nil, paymentResult: PaymentResult? = nil, loyaltyResult: [LoyaltyResult]? = nil, reversedAmount: Decimal? = nil) {
         self.response = response
         self.saleData = saleData
         self.poiData = poiData

--- a/Sources/TerminalAPIKit/Models/Rebates.swift
+++ b/Sources/TerminalAPIKit/Models/Rebates.swift
@@ -10,7 +10,7 @@ import Foundation
 public final class Rebates: Codable {
     
     /// Undocumented.
-    public let totalRebate: Double?
+    public let totalRebate: Decimal?
     
     /// Undocumented.
     public let rebateLabel: String?
@@ -23,7 +23,7 @@ public final class Rebates: Codable {
     /// - Parameter totalRebate: Undocumented.
     /// - Parameter rebateLabel: Undocumented.
     /// - Parameter saleItemRebate: Undocumented.
-    public init(totalRebate: Double? = nil, rebateLabel: String? = nil, saleItemRebate: [SaleItemRebate]? = nil) {
+    public init(totalRebate: Decimal? = nil, rebateLabel: String? = nil, saleItemRebate: [SaleItemRebate]? = nil) {
         self.totalRebate = totalRebate
         self.rebateLabel = rebateLabel
         self.saleItemRebate = saleItemRebate

--- a/Sources/TerminalAPIKit/Models/Requests/ReversalRequest.swift
+++ b/Sources/TerminalAPIKit/Models/Requests/ReversalRequest.swift
@@ -27,7 +27,7 @@ public final class ReversalRequest: Request {
     public let originalPOITransaction: OriginalPOITransaction
     
     /// Amount of the payment or loyalty to reverse..
-    public let reversedAmount: Double?
+    public let reversedAmount: Decimal?
     
     /// Reason of the payment or loyalty reversal..
     public let reversalReason: ReversalReason
@@ -42,7 +42,7 @@ public final class ReversalRequest: Request {
     /// - Parameter reversedAmount: Amount of the payment or loyalty to reverse..
     /// - Parameter reversalReason: Reason of the payment or loyalty reversal..
     /// - Parameter customerOrder: Undocumented.
-    public init(saleData: SaleData? = nil, originalPOITransaction: OriginalPOITransaction, reversedAmount: Double? = nil, reversalReason: ReversalReason, customerOrder: CustomerOrder? = nil) {
+    public init(saleData: SaleData? = nil, originalPOITransaction: OriginalPOITransaction, reversedAmount: Decimal? = nil, reversalReason: ReversalReason, customerOrder: CustomerOrder? = nil) {
         self.saleData = saleData
         self.originalPOITransaction = originalPOITransaction
         self.reversedAmount = reversedAmount

--- a/Sources/TerminalAPIKit/Models/Responses/ReversalResponse.swift
+++ b/Sources/TerminalAPIKit/Models/Responses/ReversalResponse.swift
@@ -24,7 +24,7 @@ public final class ReversalResponse: Response {
     public let originalPOITransaction: OriginalPOITransaction?
     
     /// Amount of the payment or loyalty to reverse..
-    public let reversedAmount: Double?
+    public let reversedAmount: Decimal?
     
     /// Undocumented.
     public let customerOrder: [CustomerOrder]?
@@ -44,7 +44,7 @@ public final class ReversalResponse: Response {
         response: MessageResponse,
         poiData: POIData? = nil,
         originalPOITransaction: OriginalPOITransaction? = nil,
-        reversedAmount: Double? = nil,
+        reversedAmount: Decimal? = nil,
         customerOrder: [CustomerOrder]? = nil,
         paymentReceipt: [PaymentReceipt]? = nil
     ) {

--- a/Sources/TerminalAPIKit/Models/SaleItem.swift
+++ b/Sources/TerminalAPIKit/Models/SaleItem.swift
@@ -24,13 +24,13 @@ public final class SaleItem: Codable {
     public let unitOfMeasure: UnitOfMeasure?
     
     /// Product quantity
-    public let quantity: Double?
+    public let quantity: Decimal?
     
     /// Price per unit of product
-    public let unitPrice: Double?
+    public let unitPrice: Decimal?
     
     /// Total amount of the item line.
-    public let itemAmount: Double
+    public let itemAmount: Decimal
     
     /// Type of taxes associated to the line item.
     public let taxCode: String?
@@ -57,7 +57,7 @@ public final class SaleItem: Codable {
     /// - Parameter saleChannel: Commercial or distribution channel associated to the line item.
     /// - Parameter productLabel: Undocumented.
     /// - Parameter additionalProductInfo: Additionl information related to the line item.
-    public init(itemIdentifier: Int, productCode: String, eanUpc: String? = nil, unitOfMeasure: UnitOfMeasure? = nil, quantity: Double? = nil, unitPrice: Double? = nil, itemAmount: Double, taxCode: String? = nil, saleChannel: String? = nil, productLabel: String? = nil, additionalProductInfo: String? = nil) {
+    public init(itemIdentifier: Int, productCode: String, eanUpc: String? = nil, unitOfMeasure: UnitOfMeasure? = nil, quantity: Decimal? = nil, unitPrice: Decimal? = nil, itemAmount: Decimal, taxCode: String? = nil, saleChannel: String? = nil, productLabel: String? = nil, additionalProductInfo: String? = nil) {
         self.itemIdentifier = itemIdentifier
         self.productCode = productCode
         self.eanUpc = eanUpc

--- a/Sources/TerminalAPIKit/Models/SaleItemRebate.swift
+++ b/Sources/TerminalAPIKit/Models/SaleItemRebate.swift
@@ -24,10 +24,10 @@ public final class SaleItemRebate: Codable {
     public let unitOfMeasure: UnitOfMeasure?
     
     /// Product quantity
-    public let quantity: Double?
+    public let quantity: Decimal?
     
     /// Total amount of the item line.
-    public let itemAmount: Double?
+    public let itemAmount: Decimal?
     
     /// Short text to qualify a rebate on an line item.
     public let rebateLabel: String?
@@ -41,7 +41,7 @@ public final class SaleItemRebate: Codable {
     /// - Parameter quantity: Product quantity
     /// - Parameter itemAmount: Total amount of the item line.
     /// - Parameter rebateLabel: Short text to qualify a rebate on an line item.
-    public init(itemIdentifier: Int, productCode: String, eanUpc: String? = nil, unitOfMeasure: UnitOfMeasure? = nil, quantity: Double? = nil, itemAmount: Double? = nil, rebateLabel: String? = nil) {
+    public init(itemIdentifier: Int, productCode: String, eanUpc: String? = nil, unitOfMeasure: UnitOfMeasure? = nil, quantity: Decimal? = nil, itemAmount: Decimal? = nil, rebateLabel: String? = nil) {
         self.itemIdentifier = itemIdentifier
         self.productCode = productCode
         self.eanUpc = eanUpc

--- a/Sources/TerminalAPIKit/Models/StoredValueData.swift
+++ b/Sources/TerminalAPIKit/Models/StoredValueData.swift
@@ -30,7 +30,7 @@ public final class StoredValueData: Codable {
     public let eanUpc: String?
     
     /// Total amount of the item line.
-    public let itemAmount: Double?
+    public let itemAmount: Decimal?
     
     /// Currency of a monetary amount.
     public let currency: String?
@@ -45,7 +45,7 @@ public final class StoredValueData: Codable {
     /// - Parameter eanUpc: Standard product code of item purchased with the transaction.
     /// - Parameter itemAmount: Total amount of the item line.
     /// - Parameter currency: Currency of a monetary amount.
-    public init(storedValueProvider: String? = nil, storedValueTransactionType: StoredValueTransactionType, storedValueAccountIdentifier: StoredValueAccountIdentifier? = nil, originalPOITransaction: OriginalPOITransaction? = nil, productCode: String? = nil, eanUpc: String? = nil, itemAmount: Double? = nil, currency: String? = nil) {
+    public init(storedValueProvider: String? = nil, storedValueTransactionType: StoredValueTransactionType, storedValueAccountIdentifier: StoredValueAccountIdentifier? = nil, originalPOITransaction: OriginalPOITransaction? = nil, productCode: String? = nil, eanUpc: String? = nil, itemAmount: Decimal? = nil, currency: String? = nil) {
         self.storedValueProvider = storedValueProvider
         self.storedValueTransactionType = storedValueTransactionType
         self.storedValueAccountIdentifier = storedValueAccountIdentifier

--- a/Sources/TerminalAPIKit/Models/StoredValueResult.swift
+++ b/Sources/TerminalAPIKit/Models/StoredValueResult.swift
@@ -21,7 +21,7 @@ public final class StoredValueResult: Codable {
     public let eanUpc: String?
     
     /// Total amount of the item line.
-    public let itemAmount: Double?
+    public let itemAmount: Decimal?
     
     /// Currency of a monetary amount.
     public let currency: String?
@@ -37,7 +37,7 @@ public final class StoredValueResult: Codable {
     /// - Parameter itemAmount: Total amount of the item line.
     /// - Parameter currency: Currency of a monetary amount.
     /// - Parameter storedValueAccountStatus: Data related to the result of the stored value card transaction.
-    public init(storedValueTransactionType: StoredValueTransactionType, productCode: String? = nil, eanUpc: String? = nil, itemAmount: Double? = nil, currency: String? = nil, storedValueAccountStatus: StoredValueAccountStatus? = nil) {
+    public init(storedValueTransactionType: StoredValueTransactionType, productCode: String? = nil, eanUpc: String? = nil, itemAmount: Decimal? = nil, currency: String? = nil, storedValueAccountStatus: StoredValueAccountStatus? = nil) {
         self.storedValueTransactionType = storedValueTransactionType
         self.productCode = productCode
         self.eanUpc = eanUpc

--- a/TerminalAPIKit.podspec
+++ b/TerminalAPIKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'TerminalAPIKit'
-  s.version = '1.3.0'
+  s.version = '2.0.0'
   s.summary = "Adyen Terminal API for iOS"
   s.description = <<-DESC
     TerminalAPIKit for iOS helps with integrating Adyen's Terminal API into your iOS POS app.


### PR DESCRIPTION
## Release 2.0.0 brings the following changes:
### Added:
- Helper functions for [deriving the key](https://github.com/Adyen/adyen-terminal-api-ios#derive-the-encryption-key) used to encrypt the communication when using for local TAPI integration.
- Documentation regarding [local TAPI integration](https://github.com/Adyen/adyen-terminal-api-ios#local-terminal-api-integration).
- Support for decoding `ISO8601` dates without optional milliseconds.

### Changed:
- Changed any numeric amount type from `Double` to `Decimal`.