### PR TITLE
Allow iOS12 minimum target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "TerminalAPIKit",
-    platforms: [.iOS(.v13), .macOS(.v10_15)],
+    platforms: [.iOS(.v12), .macOS(.v10_15)],
     products: [
         .library(
             name: "TerminalAPIKit",

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Once the key is derived, you are ready to encrypt your local communications.
 
 ## Requirements
 To use TerminalAPIKit for iOS, you need:
-- iOS 13.0 or later
+- iOS 12.0 or later
 - Xcode 13.4 or later
 - Swift 5.6
 

--- a/README.md
+++ b/README.md
@@ -116,9 +116,10 @@ Once the key is derived, you are ready to encrypt your local communications.
    ```swift
    let encryptionKey: EncryptionKey = // the key you derived earlier
    let request: Message<PaymentRequest> = // the payment request you created
-   let encryptedMessage: Data = try request.encrypt(using: encryptionKey)
+   let encryptedMessage: EncryptedMessage = try request.encrypt(using: encryptionKey)
+   let json: Data = try Coder.encode(encryptedMessage)
    ```
-3. Send the `encryptedMessage` to the terminal.
+3. Send the `json` to the terminal.
 4. When you receive the response from the terminal, decrypt the response.
    ```swift
    let key: EncryptionKey = // the key you derived earlier

--- a/Sources/TerminalAPIKit/Crypto/HMAC.swift
+++ b/Sources/TerminalAPIKit/Crypto/HMAC.swift
@@ -16,6 +16,59 @@ import CryptoKit
 ///   - key: The key to use when calculating the HMAC.
 /// - Returns: The HMAC for the given data and key.
 public func hmac(for input: Data, key: Data) -> Data {
-    let hmac = HMAC<SHA256>.authenticationCode(for: input, using: SymmetricKey(data: key))
-    return Data(hmac)
+    if #available(iOS 13.0, *) {
+        let hmac = HMAC<SHA256>.authenticationCode(for: input, using: SymmetricKey(data: key))
+        return Data(hmac)
+    } else {
+        enum CryptoAlgorithm {
+            case MD5, SHA1, SHA224, SHA256, SHA384, SHA512
+
+            var HMACAlgorithm: CCHmacAlgorithm {
+                var result: Int = 0
+                switch self {
+                case .MD5:      result = kCCHmacAlgMD5
+                case .SHA1:     result = kCCHmacAlgSHA1
+                case .SHA224:   result = kCCHmacAlgSHA224
+                case .SHA256:   result = kCCHmacAlgSHA256
+                case .SHA384:   result = kCCHmacAlgSHA384
+                case .SHA512:   result = kCCHmacAlgSHA512
+                }
+                return CCHmacAlgorithm(result)
+            }
+
+            var digestLength: Int {
+                var result: Int32 = 0
+                switch self {
+                case .MD5:      result = CC_MD5_DIGEST_LENGTH
+                case .SHA1:     result = CC_SHA1_DIGEST_LENGTH
+                case .SHA224:   result = CC_SHA224_DIGEST_LENGTH
+                case .SHA256:   result = CC_SHA256_DIGEST_LENGTH
+                case .SHA384:   result = CC_SHA384_DIGEST_LENGTH
+                case .SHA512:   result = CC_SHA512_DIGEST_LENGTH
+                }
+                return Int(result)
+            }
+        }
+        
+        let algorithm = CryptoAlgorithm.SHA256
+        
+        let inputString = String(data: key, encoding: String.Encoding.utf8)!
+        let keyString = String(data: key, encoding: String.Encoding.utf8)!
+        
+        let str = inputString.cString(using: String.Encoding.utf8)
+        let strLen = Int(inputString.lengthOfBytes(using: String.Encoding.utf8))
+        let digestLen = algorithm.digestLength
+        let result = UnsafeMutablePointer<CUnsignedChar>.allocate(capacity: digestLen)
+        let keyStr = keyString.cString(using: String.Encoding.utf8)
+        let keyLen = Int(keyString.lengthOfBytes(using: String.Encoding.utf8))
+
+        CCHmac(algorithm.HMACAlgorithm, keyStr!, keyLen, str!, strLen, result)
+
+        let digest = Data(bytes: result, count: digestLen)
+
+        result.deallocate()
+
+        return digest
+
+    }
 }

--- a/Tests/TerminalAPIKitTests/EncryptedMessageTests.swift
+++ b/Tests/TerminalAPIKitTests/EncryptedMessageTests.swift
@@ -12,8 +12,15 @@ import CryptoKit
 final class EncryptedMessageTests: XCTestCase {
     
     func generateTestKey() -> EncryptionKey {
-        let hmacKey = SymmetricKey(size: .bits256)
-        let aesKey = SymmetricKey(size: .bits256)
+        let hmacKey: ContiguousBytes
+        let aesKey: ContiguousBytes
+        if #available(iOS 13.0, *) {
+            hmacKey = SymmetricKey(size: .bits256)
+            aesKey = SymmetricKey(size: .bits256)
+        } else {
+            hmacKey = Data(count: 256 / 8)
+            aesKey = Data(count: 256 / 8)
+        }
         let nonce = Data(secureRandomBytesWithCount: 16)!
         var data = Data(capacity: 80)
         


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
We would like to switch from our self generated model (using quicktype) to this awesome package. 
However we are currently still facing iOS 12, but the changes needed to support the version are only a few.

I decided to provide the community with the patch, and hope it might be appreciated.
If maintaining an older iOS version or crypto fallback hinders future development then I would understand and just keep it in a fork.

What do you think?

## Tested scenarios
iOS12 local terminal api