### PR TITLE
change Input.menuEntryNumber to optional Int array

### DIFF
--- a/Sources/TerminalAPIKit/Models/Input.swift
+++ b/Sources/TerminalAPIKit/Models/Input.swift
@@ -27,8 +27,8 @@ public final class Input: Codable {
     /// Undocumented.
     public let password: [UInt8]?
     
-    /// Undocumented.
-    public let menuEntryNumber: Int?
+    /// Shows which option was selected. A value of 1 means selected, 0 means not selected..
+    public let menuEntryNumber: [Int]?
     
     /// Initializes the Input.
     ///
@@ -39,7 +39,7 @@ public final class Input: Codable {
     /// - Parameter digitInput: Undocumented.
     /// - Parameter password: Undocumented.
     /// - Parameter menuEntryNumber: Undocumented.
-    public init(inputCommand: InputCommand, confirmedFlag: Bool? = nil, functionKey: String? = nil, textInput: String? = nil, digitInput: String? = nil, password: [UInt8]? = nil, menuEntryNumber: Int? = nil) {
+    public init(inputCommand: InputCommand, confirmedFlag: Bool? = nil, functionKey: String? = nil, textInput: String? = nil, digitInput: String? = nil, password: [UInt8]? = nil, menuEntryNumber: [Int]? = nil) {
         self.inputCommand = inputCommand
         self.confirmedFlag = confirmedFlag
         self.functionKey = functionKey


### PR DESCRIPTION
## Summary
Bringing `menuEntryNumber` in line with [the documentation](https://docs.adyen.com/point-of-sale/shopper-engagement/shopper-input/inputresponsemenunexo/) - it is an optional array of `Int`s, not an `Int`.

I've separately also added `DisplayOutput` to `InputRequest` [here](https://github.com/Adyen/adyen-terminal-api-ios/commit/64a11ca7b2a0e9dc5821fa4a3b9fb20160bd42a5), but I've left it out of this PR in case #23 is approved.

## Tested scenarios
This allows `InputResponse` to properly decode when making a "MenuButtons" `InputRequest` [as seen here](https://docs.adyen.com/point-of-sale/shopper-engagement/shopper-input/menu/).


**Fixed issue**:  N/A
