### PR TITLE
Add support for `AdminRequest` Sessions

### DIFF
--- a/Sources/TerminalAPIKit/Models/Enumerations/OperationType.swift
+++ b/Sources/TerminalAPIKit/Models/Enumerations/OperationType.swift
@@ -2,7 +2,7 @@
 //  OperationType.swift
 //  TerminalAPIKit
 //
-//  Created by Andrew Gates on 8/8/23.
+//  Copyright (c) 2023 Adyen N.V.
 //
 
 import Foundation

--- a/Sources/TerminalAPIKit/Models/Enumerations/OperationType.swift
+++ b/Sources/TerminalAPIKit/Models/Enumerations/OperationType.swift
@@ -1,0 +1,14 @@
+//
+//  OperationType.swift
+//  TerminalAPIKit
+//
+//  Created by Andrew Gates on 8/8/23.
+//
+
+import Foundation
+
+public enum OperationType: String, Codable {
+    case inputRequest = "InputRequest"
+    case displayRequest = "DisplayRequest"
+    case payment = "Payment"
+}

--- a/Sources/TerminalAPIKit/Models/Enumerations/OperationVariant.swift
+++ b/Sources/TerminalAPIKit/Models/Enumerations/OperationVariant.swift
@@ -1,0 +1,12 @@
+//
+//  OperationVariant.swift
+//  
+//
+//  Created by Andrew on 9/5/23.
+//
+
+import Foundation
+
+public enum OperationVariant: String, Codable {
+    case waitingScreen = "WaitingScreen"
+}

--- a/Sources/TerminalAPIKit/Models/Enumerations/OperationVariant.swift
+++ b/Sources/TerminalAPIKit/Models/Enumerations/OperationVariant.swift
@@ -2,7 +2,7 @@
 //  OperationVariant.swift
 //  
 //
-//  Created by Andrew on 9/5/23.
+//  Copyright (c) 2023 Adyen N.V.
 //
 
 import Foundation

--- a/Sources/TerminalAPIKit/Models/Enumerations/SessionType.swift
+++ b/Sources/TerminalAPIKit/Models/Enumerations/SessionType.swift
@@ -2,7 +2,7 @@
 //  SessionType.swift
 //  TerminalAPIKit
 //
-//  Created by Andrew Gates on 8/8/23.
+//  Copyright (c) 2023 Adyen N.V.
 //
 
 import Foundation

--- a/Sources/TerminalAPIKit/Models/Enumerations/SessionType.swift
+++ b/Sources/TerminalAPIKit/Models/Enumerations/SessionType.swift
@@ -1,0 +1,13 @@
+//
+//  SessionType.swift
+//  TerminalAPIKit
+//
+//  Created by Andrew Gates on 8/8/23.
+//
+
+import Foundation
+
+public enum SessionType: String, Codable {
+    case begin = "Begin"
+    case end = "End"
+}

--- a/Sources/TerminalAPIKit/Models/Operation.swift
+++ b/Sources/TerminalAPIKit/Models/Operation.swift
@@ -1,0 +1,32 @@
+//
+//  Operation.swift
+//  TerminalAPIKit
+//
+//  Created by Andrew Gates on 8/8/23.
+//
+
+import Foundation
+
+public final class Operation: Codable {
+
+    /// the type of request after which the waiting screen shows: InputRequest, DisplayRequest, and Payment
+    public let type:OperationType
+    
+    /// For now, the Operation.Variant can only have WaitingScreen as value. This shows the waiting screen animation on the terminal after every request until you end the session.
+    public let variant:String
+    
+    /// UserInterfaceData.WaitingScreenTimeoutMs: how long the waiting screen is shown on the terminal display, in milliseconds.
+    public let userInterfaceData:UserInterfaceData
+    
+    public init(type: OperationType, variant: String, userInterfaceData: UserInterfaceData) {
+        self.type = type
+        self.variant = variant
+        self.userInterfaceData = userInterfaceData
+    }
+    
+    internal enum CodingKeys: String, CodingKey {
+        case type = "Type"
+        case variant = "Variant"
+        case userInterfaceData = "UserInterfaceData"
+    }
+}

--- a/Sources/TerminalAPIKit/Models/Operation.swift
+++ b/Sources/TerminalAPIKit/Models/Operation.swift
@@ -2,27 +2,27 @@
 //  Operation.swift
 //  TerminalAPIKit
 //
-//  Created by Andrew Gates on 8/8/23.
+//  Copyright (c) 2023 Adyen N.V.
 //
 
 import Foundation
 
 public final class Operation: Codable {
 
-    /// The type of request after which the waiting screen shows: InputRequest, DisplayRequest, and Payment
+    /// The type of request after which the waiting screen shows
     public let type: OperationType
     
     /// For now, the Operation.Variant can only have WaitingScreen as value. This shows the waiting screen animation on the terminal after every request until you end the session.
     public let variant: OperationVariant
     
-    /// UserInterfaceData.WaitingScreenTimeoutMs: how long the waiting screen is shown on the terminal display, in milliseconds.
+    /// Contains UI parameters related to the operation.
     public let userInterfaceData: UserInterfaceData
     
     /// Initializes the Operation.
     ///
-    /// - Parameter type: Undocumented.
-    /// - Parameter variant: Undocumented.
-    /// - Parameter userInterfaceData: Undocumented.
+    /// - Parameter type: The type of request after which the waiting screen shows.
+    /// - Parameter variant: The variant of the operation.
+    /// - Parameter userInterfaceData: Contains UI parameters related to the operation.
     public init(type: OperationType, variant: OperationVariant, userInterfaceData: UserInterfaceData) {
         self.type = type
         self.variant = variant

--- a/Sources/TerminalAPIKit/Models/Operation.swift
+++ b/Sources/TerminalAPIKit/Models/Operation.swift
@@ -9,16 +9,21 @@ import Foundation
 
 public final class Operation: Codable {
 
-    /// the type of request after which the waiting screen shows: InputRequest, DisplayRequest, and Payment
-    public let type:OperationType
+    /// The type of request after which the waiting screen shows: InputRequest, DisplayRequest, and Payment
+    public let type: OperationType
     
     /// For now, the Operation.Variant can only have WaitingScreen as value. This shows the waiting screen animation on the terminal after every request until you end the session.
-    public let variant:String
+    public let variant: OperationVariant
     
     /// UserInterfaceData.WaitingScreenTimeoutMs: how long the waiting screen is shown on the terminal display, in milliseconds.
-    public let userInterfaceData:UserInterfaceData
+    public let userInterfaceData: UserInterfaceData
     
-    public init(type: OperationType, variant: String, userInterfaceData: UserInterfaceData) {
+    /// Initializes the Operation.
+    ///
+    /// - Parameter type: Undocumented.
+    /// - Parameter variant: Undocumented.
+    /// - Parameter userInterfaceData: Undocumented.
+    public init(type: OperationType, variant: OperationVariant, userInterfaceData: UserInterfaceData) {
         self.type = type
         self.variant = variant
         self.userInterfaceData = userInterfaceData

--- a/Sources/TerminalAPIKit/Models/Session.swift
+++ b/Sources/TerminalAPIKit/Models/Session.swift
@@ -2,7 +2,7 @@
 //  Session.swift
 //  TerminalAPIKit
 //
-//  Created by Andrew Gates on 8/8/23.
+//  Copyright (c) 2023 Adyen N.V.
 //
 
 import Foundation
@@ -17,8 +17,8 @@ public final class Session: Codable {
     
     /// Initializes the Session.
     ///
-    /// - Parameter id: Undocumented.
-    /// - Parameter type: Undocumented.
+    /// - Parameter id: the unique reference of the session.
+    /// - Parameter type: the type of session.
     public init(id: Int, type: SessionType) {
         self.id = id
         self.type = type;

--- a/Sources/TerminalAPIKit/Models/Session.swift
+++ b/Sources/TerminalAPIKit/Models/Session.swift
@@ -9,13 +9,17 @@ import Foundation
 
 public final class Session: Codable {
     
-    /// the unique reference of the session.
+    /// The unique reference of the session.
     public let id: Int
     
-    /// set the value to Begin to start the session, set the value to End to end the session.
+    /// The type of the transaction. Use ``SessionType/Begin`` to start a session, and ``SessionType/End`` to end the session.
     public let type: SessionType
     
-    public init(id:Int, type:SessionType) {
+    /// Initializes the Session.
+    ///
+    /// - Parameter id: Undocumented.
+    /// - Parameter type: Undocumented.
+    public init(id: Int, type: SessionType) {
         self.id = id
         self.type = type;
     }

--- a/Sources/TerminalAPIKit/Models/Session.swift
+++ b/Sources/TerminalAPIKit/Models/Session.swift
@@ -1,0 +1,27 @@
+//
+//  Session.swift
+//  TerminalAPIKit
+//
+//  Created by Andrew Gates on 8/8/23.
+//
+
+import Foundation
+
+public final class Session: Codable {
+    
+    /// the unique reference of the session.
+    public let id: Int
+    
+    /// set the value to Begin to start the session, set the value to End to end the session.
+    public let type: SessionType
+    
+    public init(id:Int, type:SessionType) {
+        self.id = id
+        self.type = type;
+    }
+    
+    internal enum CodingKeys: String, CodingKey {
+        case id = "Id"
+        case type = "Type"
+    }
+}

--- a/Sources/TerminalAPIKit/Models/SessionContainer.swift
+++ b/Sources/TerminalAPIKit/Models/SessionContainer.swift
@@ -2,7 +2,7 @@
 //  SessionContainer.swift
 //  TerminalAPIKit
 //
-//  Created by Andrew Gates on 8/8/23.
+//  Copyright (c) 2023 Adyen N.V.
 //
 // Used in AdminRequests
 // https://docs.adyen.com/point-of-sale/shopper-engagement/create-session/
@@ -15,8 +15,8 @@ public final class SessionContainer: Codable {
     
     /// Initializes the SessionContainer.
     ///
-    /// - Parameter session: Undocumented.
-    /// - Parameter operation: Undocumented.
+    /// - Parameter session: The session.
+    /// - Parameter operation: The operation.
     public init(session: Session, operation: [Operation]? = nil) {
         self.session = session
         self.operation = operation

--- a/Sources/TerminalAPIKit/Models/SessionContainer.swift
+++ b/Sources/TerminalAPIKit/Models/SessionContainer.swift
@@ -13,7 +13,7 @@ public final class SessionContainer: Codable {
     public let session:Session
     public let operation:[Operation]?
     
-    public init(session: Session, operation: [Operation]?) {
+    public init(session: Session, operation: [Operation]? = nil) {
         self.session = session
         self.operation = operation
     }

--- a/Sources/TerminalAPIKit/Models/SessionContainer.swift
+++ b/Sources/TerminalAPIKit/Models/SessionContainer.swift
@@ -10,9 +10,13 @@
 import Foundation
 
 public final class SessionContainer: Codable {
-    public let session:Session
-    public let operation:[Operation]?
+    public let session: Session
+    public let operation: [Operation]?
     
+    /// Initializes the SessionContainer.
+    ///
+    /// - Parameter session: Undocumented.
+    /// - Parameter operation: Undocumented.
     public init(session: Session, operation: [Operation]? = nil) {
         self.session = session
         self.operation = operation

--- a/Sources/TerminalAPIKit/Models/SessionContainer.swift
+++ b/Sources/TerminalAPIKit/Models/SessionContainer.swift
@@ -1,0 +1,25 @@
+//
+//  SessionContainer.swift
+//  TerminalAPIKit
+//
+//  Created by Andrew Gates on 8/8/23.
+//
+// Used in AdminRequests
+// https://docs.adyen.com/point-of-sale/shopper-engagement/create-session/
+
+import Foundation
+
+public final class SessionContainer: Codable {
+    public let session:Session
+    public let operation:[Operation]?
+    
+    public init(session: Session, operation: [Operation]?) {
+        self.session = session
+        self.operation = operation
+    }
+    
+    internal enum CodingKeys: String, CodingKey {
+        case session = "Session"
+        case operation = "Operation"
+    }
+}

--- a/Sources/TerminalAPIKit/Models/UserInterfaceData.swift
+++ b/Sources/TerminalAPIKit/Models/UserInterfaceData.swift
@@ -9,10 +9,13 @@ import Foundation
 
 public final class UserInterfaceData: Codable {
 
-    /// how long the waiting screen is shown on the terminal display, in milliseconds.
-    public let waitingScreenTimeoutMs:Int
+    /// How long the waiting screen is shown on the terminal display, in milliseconds.
+    public let waitingScreenTimeoutMs: Int
     
-    public init(waitingScreenTimeoutMs:Int) {
+    /// Initializes the UserInterfaceData.
+    ///
+    /// - Parameter waitingScreenTimeoutMs: Undocumented.
+    public init(waitingScreenTimeoutMs: Int) {
         self.waitingScreenTimeoutMs = waitingScreenTimeoutMs
     }
     

--- a/Sources/TerminalAPIKit/Models/UserInterfaceData.swift
+++ b/Sources/TerminalAPIKit/Models/UserInterfaceData.swift
@@ -2,7 +2,7 @@
 //  UserInterfaceData.swift
 //  TerminalAPIKit
 //
-//  Created by Andrew Gates on 8/8/23.
+//  Copyright (c) 2023 Adyen N.V.
 //
 
 import Foundation
@@ -14,7 +14,7 @@ public final class UserInterfaceData: Codable {
     
     /// Initializes the UserInterfaceData.
     ///
-    /// - Parameter waitingScreenTimeoutMs: Undocumented.
+    /// - Parameter waitingScreenTimeoutMs: how long the waiting screen is shown on the terminal display, in milliseconds.
     public init(waitingScreenTimeoutMs: Int) {
         self.waitingScreenTimeoutMs = waitingScreenTimeoutMs
     }

--- a/Sources/TerminalAPIKit/Models/UserInterfaceData.swift
+++ b/Sources/TerminalAPIKit/Models/UserInterfaceData.swift
@@ -1,0 +1,22 @@
+//
+//  UserInterfaceData.swift
+//  TerminalAPIKit
+//
+//  Created by Andrew Gates on 8/8/23.
+//
+
+import Foundation
+
+public final class UserInterfaceData: Codable {
+
+    /// how long the waiting screen is shown on the terminal display, in milliseconds.
+    public let waitingScreenTimeoutMs:Int
+    
+    public init(waitingScreenTimeoutMs:Int) {
+        self.waitingScreenTimeoutMs = waitingScreenTimeoutMs
+    }
+    
+    internal enum CodingKeys: String, CodingKey {
+        case waitingScreenTimeoutMs = "WaitingScreenTimeoutMs"
+    }
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Adds support for `AdminRequest` Begin/End session as seen in [Create a session documentation](https://docs.adyen.com/point-of-sale/shopper-engagement/create-session/).

All added classes/additions mirror the naming found in that documentation, however I had to introduce a new class which I named `SessionContainer` to combine the `Session` and `[Operation]` objects for JSON serialization, which can then be base64 encoded to a string and used for `AdminRequest.ServiceIdentification`

Please let me know if you'd prefer a different name for `SessionContainer` - I couldn't find a similar concept in adyen-terminal-api-ios to base the naming off of.

## Tested scenarios
I've tested this with both Begin and End session calls using an AMS1 device.

